### PR TITLE
Another attempt to fix locomotivecms/wagon#255

### DIFF
--- a/lib/locomotive/steam/adapters/memory.rb
+++ b/lib/locomotive/steam/adapters/memory.rb
@@ -9,7 +9,7 @@ module Locomotive::Steam
   module Memory
   end
 
-  class MemoryAdapter < Struct.new(:collection)
+  MemoryAdapter = Struct.new(:collection) do
 
     include Locomotive::Steam::Adapters::Concerns::Key
 

--- a/lib/locomotive/steam/middlewares/thread_safe.rb
+++ b/lib/locomotive/steam/middlewares/thread_safe.rb
@@ -1,6 +1,6 @@
 module Locomotive::Steam::Middlewares
 
-  class ThreadSafe < Struct.new(:app)
+  ThreadSafe = Struct.new(:app) do
 
     attr_accessor :env
 


### PR DESCRIPTION
And perhaps locomotivecms/wagon#254 as well.

Moral of the story? Don't inherit from Struct:
https://u.osu.edu/gee.24/2012/12/13/dont-inherit-from-struct

attr_extras seems like an even better option that would avoid warnings:
http://thepugautomatic.com/2013/08/struct-inheritance-is-overused