### PR TITLE
guard against assignation to nil value

### DIFF
--- a/lib/locomotive/steam/adapters/filesystem/yaml_loaders/content_type.rb
+++ b/lib/locomotive/steam/adapters/filesystem/yaml_loaders/content_type.rb
@@ -66,6 +66,7 @@ module Locomotive
                     if (option = list.at(position)).nil?
                       list << { _id: name, name: { locale => name }, position: position }
                     else
+                      option[name] ||= {}
                       option[name][locale] = name
                     end
                   end


### PR DESCRIPTION
In some of my Wagon project, I have an error such as nil has no = operator. This guards against such case.