### PR TITLE
Fixed previous next feature for content entries

### DIFF
--- a/lib/locomotive/steam/repositories/content_entry_repository.rb
+++ b/lib/locomotive/steam/repositories/content_entry_repository.rb
@@ -171,7 +171,7 @@ module Locomotive
 
         conditions = prepare_conditions({ k(name, op) => i18n_value_of(entry, name) })
 
-        public_send(op == 'gt' ? :last : :first) do
+        public_send(op == 'gt' ? :first : :last) do
           where(conditions).order_by(order_by)
         end
       end

--- a/spec/unit/repositories/content_entry_repository_spec.rb
+++ b/spec/unit/repositories/content_entry_repository_spec.rb
@@ -130,7 +130,8 @@ describe Locomotive::Steam::ContentEntryRepository do
       [
         { content_type_id: 1, _position: 0, _label: 'Update #1', title: { fr: 'Mise a jour #1' }, text: { en: 'added some free stuff', fr: 'phrase FR' }, date: '2009/05/12', category: 'General' },
         { content_type_id: 1, _position: 1, _label: 'Update #2', title: { fr: 'Mise a jour #2' }, text: { en: 'bla bla', fr: 'blabbla' }, date: '2009/05/12', category: 'General' },
-        { content_type_id: 1, _position: 2, _label: 'Update #3', title: { fr: 'Mise a jour #2' }, text: { en: 'bla bla', fr: 'blabbla' }, date: '2009/05/12', category: 'General' }
+        { content_type_id: 1, _position: 2, _label: 'Update #3', title: { fr: 'Mise a jour #2' }, text: { en: 'bla bla', fr: 'blabbla' }, date: '2009/05/12', category: 'General' },
+        { content_type_id: 1, _position: 3, _label: 'Update #4', title: { fr: 'Mise a jour #2' }, text: { en: 'bla bla', fr: 'blabbla' }, date: '2009/05/12', category: 'General' }
       ]
     end
 
@@ -141,7 +142,7 @@ describe Locomotive::Steam::ContentEntryRepository do
 
     context 'being last' do
 
-      let(:entry) { instance_double('Entry', content_type: type, _position: 2) }
+      let(:entry) { instance_double('Entry', content_type: type, _position: 3) }
       it { is_expected.to eq nil }
 
     end
@@ -162,7 +163,8 @@ describe Locomotive::Steam::ContentEntryRepository do
       [
         { content_type_id: 1, _position: 0, _label: 'Update #1', title: { fr: 'Mise a jour #1' }, text: { en: 'added some free stuff', fr: 'phrase FR' }, date: '2009/05/12', category: 'General' },
         { content_type_id: 1, _position: 1, _label: 'Update #2', title: { fr: 'Mise a jour #2' }, text: { en: 'bla bla', fr: 'blabbla' }, date: '2009/05/12', category: 'General' },
-        { content_type_id: 1, _position: 2, _label: 'Update #3', title: { fr: 'Mise a jour #2' }, text: { en: 'bla bla', fr: 'blabbla' }, date: '2009/05/12', category: 'General' }
+        { content_type_id: 1, _position: 2, _label: 'Update #3', title: { fr: 'Mise a jour #2' }, text: { en: 'bla bla', fr: 'blabbla' }, date: '2009/05/12', category: 'General' },
+        { content_type_id: 1, _position: 3, _label: 'Update #4', title: { fr: 'Mise a jour #2' }, text: { en: 'bla bla', fr: 'blabbla' }, date: '2009/05/12', category: 'General' }
       ]
     end
 


### PR DESCRIPTION
It used to show first record for previous or last for next. 
It didn't show up in test with only 3 entries, but was clear with four. 