### PR TITLE
with_scope supports regular expression switches: i, m, x

### DIFF
--- a/lib/locomotive/steam/liquid/tags/with_scope.rb
+++ b/lib/locomotive/steam/liquid/tags/with_scope.rb
@@ -20,6 +20,12 @@ module Locomotive
 
           SYMBOL_OPERATORS_REGEXP = /(\w+\.(#{OPERATORS.join('|')})){1}\s*\:/o
 
+          REGEX_OPTIONS = {
+            'i' => Regexp::IGNORECASE,
+            'm' => Regexp::MULTILINE,
+            'x' => Regexp::EXTENDED
+          }
+
           # register the tag
           tag_name :with_scope
 
@@ -54,7 +60,14 @@ module Locomotive
           def cast_value(value)
             case value
             when Array then value.map { |_value| cast_value(_value) }
-            when /^\/[^\/]*\/$/ then Regexp.new(value[1..-2])
+            when /^\/[^\/]*\/$/
+              Regexp.new(value[1..-2])
+            when /^\/([^\/]*)\/([imx]+)$/
+              _value, _switch = $1, $2
+              re_options = _switch.split('').uniq.inject(0) do |options, letter|
+                options |= REGEX_OPTIONS[letter]
+              end
+              Regexp.new(_value, re_options)
             else
               value.respond_to?(:_id) ? value.send(:_source) : value
             end

--- a/spec/unit/liquid/tags/with_scope_spec.rb
+++ b/spec/unit/liquid/tags/with_scope_spec.rb
@@ -34,6 +34,13 @@ describe Locomotive::Steam::Liquid::Tags::WithScope do
 
   end
 
+  describe 'decode regexps with case-insensitive' do
+
+    let(:source) { "{% with_scope title: /like this/i %}{% assign conditions = with_scope %}{% endwith_scope %}" }
+    it { expect(conditions['title']).to eq(/like this/i) }
+
+  end
+
   describe 'decode content entry' do
 
     let(:entry) {
@@ -68,6 +75,14 @@ describe Locomotive::Steam::Liquid::Tags::WithScope do
     let(:assigns) { { 'my_regexp' => '/^Hello World/' } }
     let(:source) { "{% with_scope title: my_regexp %}{% assign conditions = with_scope %}{% endwith_scope %}" }
     it { expect(conditions['title']).to eq(/^Hello World/) }
+
+  end
+
+  describe 'decode a regexp stored in a context variable, with case-insensitive' do
+
+    let(:assigns) { { 'my_regexp' => '/^hello world/i' } }
+    let(:source) { "{% with_scope title: my_regexp %}{% assign conditions = with_scope %}{% endwith_scope %}" }
+    it { expect(conditions['title']).to eq(/^hello world/i) }
 
   end
 


### PR DESCRIPTION
Added regular expression switches `imx` for `with_scope` tag.

Now we can search content entries with case insensitive like that:
```
{% with_scope title: /hello/i %}
  pages = contents.posts
{% endwith_scope %}
```

We'll get posts with title: `HELLO`, `Hello`, `Hello World` etc.
