### PR TITLE
Add option for Authorization header in consume tag

### DIFF
--- a/lib/locomotive/steam/services/external_api_service.rb
+++ b/lib/locomotive/steam/services/external_api_service.rb
@@ -16,6 +16,10 @@ module Locomotive
         username, password = options.delete(:username), options.delete(:password)
         options[:basic_auth] = { username: username, password: password } if username
 
+        # authorization header ?
+        header_auth = options.delete(:header_auth)
+        options[:headers] = { 'Authorization' => header_auth } if header_auth
+
         perform_request_to(path, options)
       end
 
@@ -37,7 +41,10 @@ module Locomotive
 
         # sanitize the options
         options[:format]  = options[:format].gsub(/[\'\"]/, '').to_sym if options.has_key?(:format)
-        options[:headers] = { 'User-Agent' => 'LocomotiveCMS' } if options[:with_user_agent]
+        if options[:with_user_agent]
+          user_agent = { 'User-Agent' => 'LocomotiveCMS' }
+          options[:headers] ? options[:headers].merge!(user_agent) : options[:headers] = user_agent
+        end
 
         response        = self.class.get(path, options)
         parsed_response = response.parsed_response

--- a/spec/unit/services/external_api_service_spec.rb
+++ b/spec/unit/services/external_api_service_spec.rb
@@ -75,6 +75,16 @@ describe Locomotive::Steam::ExternalAPIService do
       end
     end
 
+    describe 'sets authorization header' do
+
+      let(:url)     { 'http://blog.locomotiveapp.org' }
+      let(:options) { { header_auth: 'letmein' } }
+      it do
+        expect(service.class).to receive(:get).with('/', { base_uri: 'http://blog.locomotiveapp.org', headers: { 'Authorization' => 'letmein' } }).and_return(response)
+        subject
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
This a common authentication method for many of the APIs we deal with and it
would be very convenient if the consume tag supported it. Perhaps this
implementation is too specific (focusing on a single HTTP header field) but if
the need exists, this could be extended to allow for passing additional header
fields.