### PR TITLE
Add 'capture selected_object' and 'contents.selected_object'

### DIFF
--- a/lib/locomotive/steam/liquid/drops/content_entry.rb
+++ b/lib/locomotive/steam/liquid/drops/content_entry.rb
@@ -16,6 +16,22 @@ module Locomotive
             @_label ||= @_source._label
           end
 
+          # Returns the content_entry type's slug and entry slug
+          # as a means of expressing a unique object to fascilitate
+          # looking up a specific object. Intended to be used within
+          # a capture block
+          #
+          # Usage:
+          #
+          # {% capture selected_object %}
+          #   {{ contents.products.first.select }}
+          # {% endcapture %}
+          #
+          def select
+            "~" + @_source.content_type._id + "#" + _id
+          end
+          
+
           # Returns the next content for the parent content type.
           # If no content is found, nil is returned.
           #

--- a/lib/locomotive/steam/liquid/drops/content_entry_collection.rb
+++ b/lib/locomotive/steam/liquid/drops/content_entry_collection.rb
@@ -11,6 +11,10 @@ module Locomotive
             @content_type = content_type
             @repository   = repository
           end
+          
+          def find(conditions)
+            repository.find(conditions)
+          end
 
           def all
             collection.map do |entry|

--- a/lib/locomotive/steam/liquid/drops/content_types.rb
+++ b/lib/locomotive/steam/liquid/drops/content_types.rb
@@ -5,6 +5,22 @@ module Locomotive
         class ContentTypes < ::Liquid::Drop
 
           def before_method(meth)
+            
+            # Find the object specified by the value of the variable pointed to by `meth`
+            lookup = @context.find_variable(meth)
+            if lookup && lookup.strip[0] == '~' # can't use strip! here because "".strip! returns nil.
+              lookup.strip!
+
+              # Find specific object
+              entry_type, slug = lookup[1..-1].split('#')
+              if content_type = fetch_content_type(entry_type)
+                collection = ContentEntryCollection.new(content_type)
+                collection.context = @context
+                # TODO: cache this. Maybe implement context.set_variable
+                return collection.find(slug)
+              end
+            end
+            
             if content_type = fetch_content_type(meth.to_s)
               ContentEntryCollection.new(content_type)
             else


### PR DESCRIPTION
I find myself needing a "featured product"  or something similar regularly. I implemented something for a previous version of locomotive, but it's messy and I'm moving on. This is the beginning of reimplementing that functionality for the new version.

To use: assign a content_type and slug to a liquid variable:

	{% capture featured_product %}
		{{ contents.product.first.select }}
	{% endcapture %}

Future references to `contents.selected_object` (or whatever the variable was called) will result in a lookup of the specified object:

        <h2>{{contents.featured_product.title}}</h2>

I intend to implement a select field for the back office along the lines of `editable_model` (and I wish I could use that name), but I'm on a production schedule and this has to be good enough for now.

I'm also probably not giving the depth-of-thought needed to fully understand variable lookup with regard to scopes and contexts; if there is a more efficient way to do what I'm trying to do please point me in the right direction and I'll revise it. For example, caching would probably be nice (does mongo do this behind the scenes?)