### PR TITLE
return the unresized image url when imagemagick is not available

### DIFF
--- a/lib/locomotive/steam/liquid/filters/resize.rb
+++ b/lib/locomotive/steam/liquid/filters/resize.rb
@@ -5,7 +5,7 @@ module Locomotive
         module Resize
 
           def resize(input, resize_string)
-            @context.registers[:services].image_resizer.resize(input, resize_string) || input
+            @context.registers[:services].image_resizer.resize(input, resize_string)
           end
 
         end

--- a/lib/locomotive/steam/services/image_resizer_service.rb
+++ b/lib/locomotive/steam/services/image_resizer_service.rb
@@ -6,7 +6,7 @@ module Locomotive
       attr_accessor_initialize :resizer, :asset_path
 
       def resize(source, geometry)
-        return nil if disabled? || geometry.blank?
+        return get_url_or_path(source) if disabled? || geometry.blank?
 
         if file = fetch_file(source)
           file.thumb(geometry).url

--- a/spec/unit/liquid/filters/resize_spec.rb
+++ b/spec/unit/liquid/filters/resize_spec.rb
@@ -29,6 +29,23 @@ describe Locomotive::Steam::Liquid::Filters::Resize do
 
       it { is_expected.to match /\/steam\/dynamic\/.*\/240px-Metropolitan_railway_steam_locomotive_2781022036.png/ }
 
+      describe 'when imagemagick is not available' do
+
+        let(:input) {
+          double('image from liquid', url: 'http://upload.wikimedia.org/wikipedia/en/thumb/b/b5/Metropolitan_railway_steam_locomotive_2781022036.png/240px-Metropolitan_railway_steam_locomotive_2781022036.png')
+        }
+
+        before do
+          image_resizer = @context.registers[:services].image_resizer
+          allow(image_resizer).to receive(:disabled?).and_return(true)
+        end
+
+        it 'returns the original url without resizing' do
+          is_expected.to eq 'http://upload.wikimedia.org/wikipedia/en/thumb/b/b5/Metropolitan_railway_steam_locomotive_2781022036.png/240px-Metropolitan_railway_steam_locomotive_2781022036.png'
+        end
+
+      end
+
     end
 
   end


### PR DESCRIPTION
From gitter:
> When running the engine in production, the urls to my images are broken and instead the HTML reads:
```html
<img src="Locomotive::Steam::Liquid::Drops::UploadedFile">
```
> The code producing this is
```liquid
"{{ photo.image | resize: '180x120' }}"
```
and `photo` is a content_type with image of type `file`.

This fixes it by returning the resolved url.

However, it might be useful to emit a warning in the log when such a thing happen.
Or alternatively, return a fake url such as `<img src="you need to install imagemagick to resize images">`.
In particular, I found no warning nor mention of imagemagick or dragonfly in my engine logs.
Could I have your opinion on this?

Thanks for locomotivecms, it's pretty awesome :)