### PR TITLE
Support quality parameter in resize functionality

### DIFF
--- a/lib/locomotive/steam/liquid/filters/resize.rb
+++ b/lib/locomotive/steam/liquid/filters/resize.rb
@@ -4,8 +4,39 @@ module Locomotive
       module Filters
         module Resize
 
-          def resize(input, resize_string)
-            @context.registers[:services].image_resizer.resize(input, resize_string)
+          # Optional args include:
+          #   quality: <number> compress image
+          #   auto_orient: <true|false> fix EXIF orientation issues
+          #   strip: <true|false> remove extra possibly unnecessary metadata
+          #   progressive: <true|false> make JPEG progressive
+          #   optimize: <number> shortcut to quality: and also applies strip and progressive
+          #   filters: <string> access to any ImageMagick arguments 
+          def resize(input, resize_string, *args)
+            args ||= {}
+            options = []
+
+            args.flatten.each do |arg|
+              arg.each do |k, v|
+                options << case k.to_sym
+                when :quality
+                  "-quality #{v}"
+                when :optimize # Shortcut helper to set quality, progressive and strip
+                  "-quality #{v} -strip -interlace Plane"
+                when :auto_orient
+                  "-auto-orient" if v
+                when :strip
+                  "-strip" if v
+                when :progressive
+                  "-interlace Plane" if v
+                when :filters
+                  v
+                else
+                  next
+                end
+              end
+            end
+
+            @context.registers[:services].image_resizer.resize(input, resize_string, options.join(' '))
           end
 
         end

--- a/lib/locomotive/steam/services/image_resizer_service.rb
+++ b/lib/locomotive/steam/services/image_resizer_service.rb
@@ -5,14 +5,12 @@ module Locomotive
 
       attr_accessor_initialize :resizer, :asset_path
 
-      def resize(source, geometry)
+      def resize(source, geometry, convert = "")
         return get_url_or_path(source) if disabled? || geometry.blank?
 
         if file = fetch_file(source)
-          /(?<size>[^q]*)(?:q(?<quality>\d+))?/ =~ geometry
-
-          transformed_file = file.thumb(size)
-          transformed_file = transformed_file.convert("-auto-orient -quality #{quality}") if quality.present?
+          transformed_file = file.thumb(geometry)
+          transformed_file = transformed_file.convert(convert) if !convert.blank?
           transformed_file.url
         else
           Locomotive::Common::Logger.error "Unable to resize on the fly: #{source.inspect}"

--- a/lib/locomotive/steam/services/image_resizer_service.rb
+++ b/lib/locomotive/steam/services/image_resizer_service.rb
@@ -9,7 +9,11 @@ module Locomotive
         return get_url_or_path(source) if disabled? || geometry.blank?
 
         if file = fetch_file(source)
-          file.thumb(geometry).url
+          /(?<size>[^q]*)(?:q(?<quality>\d+))?/ =~ geometry
+
+          transformed_file = file.thumb(size)
+          transformed_file = transformed_file.convert("-auto-orient -quality #{quality}") if quality.present?
+          transformed_file.url
         else
           Locomotive::Common::Logger.error "Unable to resize on the fly: #{source.inspect}"
           nil

--- a/spec/unit/liquid/filters/resize_spec.rb
+++ b/spec/unit/liquid/filters/resize_spec.rb
@@ -48,6 +48,41 @@ describe Locomotive::Steam::Liquid::Filters::Resize do
 
     end
 
+    describe 'additional filters' do
+      let(:geometry) { '30x40#' }
+      subject {}
+
+      before do
+        @context.registers[:services].image_resizer = instance_spy('ImageResizerService')
+        @image_resizer = @context.registers[:services].image_resizer
+      end
+
+      it 'handles quality' do
+        resize(input, geometry, { "quality" => 70 })
+        expect(@image_resizer).to have_received(:resize).with(input, geometry, "-quality 70")
+      end
+
+      it 'handles auto_orient' do
+        resize(input, geometry, { "auto_orient" => true })
+        expect(@image_resizer).to have_received(:resize).with(input, geometry, "-auto-orient")
+      end
+
+      it "doesn't auto_orient if false" do
+        resize(input, geometry, { "auto_orient" => false })
+        expect(@image_resizer).to have_received(:resize).with(input, geometry, "")
+      end
+
+      it 'handles optimize' do
+        resize(input, geometry, { "optimize" => 75 })
+        expect(@image_resizer).to have_received(:resize).with(input, geometry, "-quality 75 -strip -interlace Plane")
+      end
+
+      it 'handles multiple and custom filters' do
+        resize(input, geometry, { "quality" => 60, "filters" => "-sepia-tone 80%" })
+        expect(@image_resizer).to have_received(:resize).with(input, geometry, "-quality 60 -sepia-tone 80%")
+      end
+    end
+
   end
 
 end

--- a/spec/unit/services/image_resizer_service_spec.rb
+++ b/spec/unit/services/image_resizer_service_spec.rb
@@ -68,6 +68,15 @@ describe Locomotive::Steam::ImageResizerService do
 
       end
 
+      describe 'additional filters' do
+        let(:input)  { '/sites/42/theme/images/banner.png' }
+        let (:filters) { [{"quality" => 70, "auto_orient" => true, "filters" => "-swirl 180"}] }
+
+        subject { service.resize(input, geometry, filters) }
+
+        it { is_expected.to match /\/steam\/dynamic\/.*\/banner.png/ }
+      end
+
     end
 
   end


### PR DESCRIPTION
This particularly relates to the following issue in the engine repo: https://github.com/locomotivecms/engine/issues/925

I really needed the ability to specify a quality along with the resize attributes. Also I have had problems recently with an images orientation not correctly matching it's EXIF data so thought I would add an `-auto-orient` command in too.

I have just deployed this to my live LocomotiveCMS system and all seems to be working well. The file size gains can be huge.

Thanks to @benhutton for your regex it works really nicely. So `img.url | resize:'800x600#q70'` is a cropped resize to 800x600 at quality 70.

This might not be exactly how you would like to support it in the new version of engine + steam, but I thought I might as well submit a pull request anyway.