### PR TITLE
 Expose position in page liquid drop

### DIFF
--- a/lib/locomotive/steam/liquid/drops/page.rb
+++ b/lib/locomotive/steam/liquid/drops/page.rb
@@ -4,7 +4,7 @@ module Locomotive
       module Drops
         class Page < I18nBase
 
-          delegate :fullpath, :depth, :seo_title, :meta_keywords, :meta_description, :redirect_url, :handle, to: :@_source
+          delegate :position, :fullpath, :depth, :seo_title, :meta_keywords, :meta_description, :redirect_url, :handle, to: :@_source
           delegate :listed?, :published?, :redirect?, :is_layout?, :templatized?, to: :@_source
 
           def title


### PR DESCRIPTION
I have a use case where I would need the page position in a liquid template. I assume it does no harm to expose this field in the corresponding drop.

Thanks