### PR TITLE
Fix CDN path

### DIFF
--- a/lib/locomotive/steam/services/asset_host_service.rb
+++ b/lib/locomotive/steam/services/asset_host_service.rb
@@ -18,12 +18,17 @@ module Locomotive
 
         return add_timestamp_suffix(source, timestamp) if source =~ Steam::IsHTTP
 
-        url = self.host ? URI.join(host, source).to_s : source
+        url = self.host ? build_url(host, source) : source
 
         add_timestamp_suffix(url, timestamp)
       end
 
       private
+
+      def build_url(host, source)
+        clean_source = source.sub(/\A^\//, '')
+        URI.join(host, clean_source).to_s
+      end
 
       def build_host(host, request, site)
         if host

--- a/spec/unit/services/asset_host_service_spec.rb
+++ b/spec/unit/services/asset_host_service_spec.rb
@@ -53,6 +53,21 @@ describe Locomotive::Steam::AssetHostService do
 
   end
 
+  describe 'the host with prefix' do
+
+    let(:host) { 'http://somewhere.net/other/' }
+    let(:source) { '/sites/42/assets/1/banner.png' }
+    it { is_expected.to eq 'http://somewhere.net/other/sites/42/assets/1/banner.png' }
+
+    describe 'also with https' do
+
+      let(:host) { 'https://somewhere.net/other/' }
+      it { is_expected.to eq 'https://somewhere.net/other/sites/42/assets/1/banner.png' }
+
+    end
+
+  end
+
   describe 'the host is a string' do
 
     let(:host) { 'http://assets.locomotivecms.com' }


### PR DESCRIPTION
Fix `URI.join` issue. Persists when you have cdn prefix (dropped prefix within Steam only).