### PR TITLE
feature: per-site asset host

### DIFF
--- a/lib/locomotive/steam/entities/site.rb
+++ b/lib/locomotive/steam/entities/site.rb
@@ -18,7 +18,8 @@ module Locomotive::Steam
         private_access:           false,
         password:                 nil,
         metafields_schema:        {},
-        metafields:               nil
+        metafields:               nil,
+        asset_host:               nil
       }.merge(attributes))
     end
 

--- a/lib/locomotive/steam/liquid/drops/site.rb
+++ b/lib/locomotive/steam/liquid/drops/site.rb
@@ -4,7 +4,7 @@ module Locomotive
       module Drops
         class Site < I18nBase
 
-          delegate :name, :domains, :seo_title, :meta_keywords, :meta_description, to: :@_source
+          delegate :name, :domains, :seo_title, :meta_keywords, :meta_description, :asset_host, to: :@_source
 
           def index
             @index ||= repository.root.to_liquid

--- a/lib/locomotive/steam/services/asset_host_service.rb
+++ b/lib/locomotive/steam/services/asset_host_service.rb
@@ -31,7 +31,9 @@ module Locomotive
       end
 
       def build_host(host, request, site)
-        if host
+        if site && site.try(:asset_host) && !site.asset_host.empty?
+          site.asset_host =~ Steam::IsHTTP ? site.asset_host : "https://#{site.asset_host}"
+        elsif host
           if host.respond_to?(:call)
             host.call(request, site)
           else

--- a/lib/locomotive/steam/services/site_finder_service.rb
+++ b/lib/locomotive/steam/services/site_finder_service.rb
@@ -6,7 +6,7 @@ module Locomotive
       attr_accessor_initialize :repository, :request
 
       def find
-        repository.by_domain(request.host)
+        repository.by_domain(request.host) if request
       end
 
     end

--- a/spec/unit/entities/site_spec.rb
+++ b/spec/unit/entities/site_spec.rb
@@ -98,4 +98,19 @@ describe Locomotive::Steam::Site do
 
   end
 
+  describe '#asset_host' do
+
+    subject { site.asset_host }
+
+    it { is_expected.to eq nil }
+
+    context 'not blank' do
+
+      let(:attributes) { { asset_host: 'http://asset.dev' } }
+      it { is_expected.to eq 'http://asset.dev' }
+
+    end
+
+  end
+
 end

--- a/spec/unit/liquid/drops/site_spec.rb
+++ b/spec/unit/liquid/drops/site_spec.rb
@@ -4,7 +4,7 @@ describe Locomotive::Steam::Liquid::Drops::Site do
 
   let(:services)  { Locomotive::Steam::Services.build_instance }
   let(:context)   { ::Liquid::Context.new({}, {}, { services: services }) }
-  let(:site)      { instance_double('Site', name: 'Locomotive', domains: ['acme.org'], seo_title: 'seo title', meta_keywords: 'keywords', meta_description: 'description', localized_attributes: {}) }
+  let(:site)      { instance_double('Site', name: 'Locomotive', domains: ['acme.org'], seo_title: 'seo title', meta_keywords: 'keywords', meta_description: 'description', localized_attributes: {}, asset_host: 'http://asset.dev') }
   let(:drop)      { described_class.new(site).tap { |d| d.context = context } }
 
   subject { drop }
@@ -15,6 +15,7 @@ describe Locomotive::Steam::Liquid::Drops::Site do
     expect(subject.meta_keywords).to eq 'keywords'
     expect(subject.meta_description).to eq 'description'
     expect(subject.domains).to eq ['acme.org']
+    expect(subject.asset_host).to eq 'http://asset.dev'
   end
 
   describe '#index' do

--- a/spec/unit/liquid/filters/html_spec.rb
+++ b/spec/unit/liquid/filters/html_spec.rb
@@ -5,7 +5,8 @@ describe Locomotive::Steam::Liquid::Filters::Html do
   include Locomotive::Steam::Liquid::Filters::Base
   include Locomotive::Steam::Liquid::Filters::Html
 
-  let(:site)          { instance_double('Site', _id: 42)}
+  let(:asset_host)    { nil }
+  let(:site)          { instance_double('Site', _id: 42, asset_host: asset_host) }
   let(:services)      { Locomotive::Steam::Services.build_instance }
   let(:context)       { instance_double('Context', registers: { services: services }) }
 
@@ -205,6 +206,10 @@ describe Locomotive::Steam::Liquid::Filters::Html do
     expect(javascript_tag('https://cdn.example.com/trash/main.js', ['defer:defer'])).to eq(result)
   end
 
+  it 'returns an image url for a given theme file without parameters' do
+    expect(theme_image_url('foo.jpg')).to eq "/sites/42/theme/images/foo.jpg"
+  end
+
   it 'returns an image tag for a given theme file without parameters' do
     expect(theme_image_tag('foo.jpg')).to eq "<img src=\"/sites/42/theme/images/foo.jpg\" >"
   end
@@ -243,6 +248,58 @@ describe Locomotive::Steam::Liquid::Filters::Html do
   </embed>
 </object>
     }.strip)
+  end
+
+  context 'asset_host' do
+    let(:asset_host)    { 'http://asset.dev' }
+
+    it 'returns an url for a stylesheet file with respect to URL-parameters' do
+      result = "http://asset.dev/sites/42/theme/stylesheets/main.css?v=42"
+      expect(stylesheet_url('main.css?v=42')).to eq(result)
+      expect(stylesheet_url('main?v=42')).to eq(result)
+    end
+
+    it 'returns a link tag for a stylesheet file' do
+      result = "<link href=\"http://asset.dev/sites/42/theme/stylesheets/main.css\" media=\"screen\" rel=\"stylesheet\" type=\"text/css\" />"
+      expect(stylesheet_tag('main.css')).to eq(result)
+      expect(stylesheet_tag('main')).to eq(result)
+      expect(stylesheet_tag(nil)).to eq('')
+    end
+
+    it 'returns a link tag for a stylesheet file with folder' do
+      result = "<link href=\"http://asset.dev/sites/42/theme/stylesheets/trash/main.css\" media=\"screen\" rel=\"stylesheet\" type=\"text/css\" />"
+      expect(stylesheet_tag('trash/main.css')).to eq(result)
+    end
+
+    it 'returns an url for a javascript file with respect to URL-parameters' do
+      expect(javascript_url('main.js?v=42')).to eq "http://asset.dev/sites/42/theme/javascripts/main.js?v=42"
+    end
+
+    it 'returns a script tag for a javascript file' do
+      result = %{<script src="http://asset.dev/sites/42/theme/javascripts/main.js" type="text/javascript" ></script>}
+      expect(javascript_tag('main.js')).to eq(result)
+      expect(javascript_tag('main')).to eq(result)
+      expect(javascript_tag(nil)).to eq('')
+    end
+
+    it 'returns a script tag for a javascript file with folder' do
+      result = %{<script src="http://asset.dev/sites/42/theme/javascripts/trash/main.js" type="text/javascript" ></script>}
+      expect(javascript_tag('trash/main.js')).to eq(result)
+      expect(javascript_tag('trash/main')).to eq(result)
+    end
+
+    it 'returns an image url for a given theme file without parameters' do
+      expect(theme_image_url('foo.jpg')).to eq "http://asset.dev/sites/42/theme/images/foo.jpg"
+    end
+
+    it 'returns an image tag for a given theme file without parameters' do
+      expect(theme_image_tag('foo.jpg')).to eq "<img src=\"http://asset.dev/sites/42/theme/images/foo.jpg\" >"
+    end
+
+    it 'returns an image tag for a given theme file with size' do
+      expect(theme_image_tag('foo.jpg', 'width:100', 'height:100')).to eq("<img src=\"http://asset.dev/sites/42/theme/images/foo.jpg\" height=\"100\" width=\"100\" >")
+    end
+
   end
 
   class EngineThemeAsset < Locomotive::Steam::ThemeAssetRepository

--- a/spec/unit/services/asset_host_service_spec.rb
+++ b/spec/unit/services/asset_host_service_spec.rb
@@ -91,9 +91,9 @@ describe Locomotive::Steam::AssetHostService do
 
   describe 'the host is a block' do
 
-    let(:request)     { instance_double('Request', ssl: true) }
-    let(:site)        { instance_double('Site', cdn: true) }
-    let(:host) { ->(request, site) { site.cdn ? "http#{request.ssl ? 's' : ''}://assets.locomotivecms.com" : nil } }
+    let(:request) { instance_double('Request', ssl: true) }
+    let(:site)    { instance_double('Site', cdn: true) }
+    let(:host)    { ->(request, site) { site.cdn ? "http#{request.ssl ? 's' : ''}://assets.locomotivecms.com" : nil } }
 
     it { is_expected.to eq 'https://assets.locomotivecms.com/sites/42/assets/1/banner.png' }
 
@@ -110,6 +110,30 @@ describe Locomotive::Steam::AssetHostService do
       it { is_expected.to eq '/sites/42/assets/1/banner.png' }
 
     end
+
+  end
+
+  describe 'the site has an asset host' do
+
+    let(:site) { instance_double('Site', asset_host: 'asset.dev') }
+    let(:host) { 'http://assets.locomotivecms.com' }
+
+    it { is_expected.to eq 'https://asset.dev/sites/42/assets/1/banner.png' }
+
+    context 'with the protocol' do
+
+      let(:site) { instance_double('Site', asset_host: 'http://asset.dev') }
+      it { is_expected.to eq 'http://asset.dev/sites/42/assets/1/banner.png' }
+
+    end
+
+    context 'with an empty string' do
+
+      let(:site) { instance_double('Site', asset_host: '') }
+      it { is_expected.to eq 'http://assets.locomotivecms.com/sites/42/assets/1/banner.png' }
+
+    end
+
 
   end
 


### PR DESCRIPTION
These are the changes to the ```steam``` library that are needed to allow for per-site asset hosts.

This augments the default behavior of setting a single asset host at the ```engine``` level.

```engine```, ```steam```, and ```wagon``` all require changes for this feature to work:

- https://github.com/interhive/engine/tree/feature-per-site-asset-host
- https://github.com/interhive/steam/tree/feature-per-site-asset-host
- https://github.com/interhive/wagon/tree/feature-per-site-asset-host

Please review and let me know if I need to make any changes.

Thanks,
Chris