### PR TITLE
Fix params are passed like string so we should add the string "1" as True for the option disable email

### DIFF
--- a/lib/locomotive/steam/middlewares/auth.rb
+++ b/lib/locomotive/steam/middlewares/auth.rb
@@ -179,7 +179,7 @@ module Locomotive::Steam
         end
 
         def disable_email
-          [1, 'true', true].include?(params[:auth_disable_email])
+          [1, '1', 'true', true].include?(params[:auth_disable_email])
         end
 
         def entry


### PR DESCRIPTION
Params are passed like a string in the post method using encoding params. So we should also match "1" as True