### PR TITLE
[IMP] add notification for reseting password

### DIFF
--- a/lib/locomotive/steam/middlewares/auth.rb
+++ b/lib/locomotive/steam/middlewares/auth.rb
@@ -76,7 +76,7 @@ module Locomotive::Steam
       def reset_password(options)
         return if authenticated?
 
-        status, entry = services.auth.reset_password(options)
+        status, entry = services.auth.reset_password(options, request)
 
         if status == :password_reset
           store_authenticated(entry)

--- a/lib/locomotive/steam/services/auth_service.rb
+++ b/lib/locomotive/steam/services/auth_service.rb
@@ -71,7 +71,7 @@ module Locomotive
         end
       end
 
-      def reset_password(options)
+      def reset_password(options, request)
         return :invalid_token       if options.reset_token.blank?
         return :password_too_short  if options.password.to_s.size < MIN_PASSWORD_LENGTH
 
@@ -87,6 +87,7 @@ module Locomotive
               '_auth_reset_token'   => nil,
               '_auth_reset_sent_at' => nil
             })
+            notify(:reset_password, entry, request)
 
             return [:"#{options.password_field}_reset", entry]
           end


### PR DESCRIPTION
Add reset notification, we need it for shopinvader as resting the password will log the user. Indeed everytime a user log in the website we need to do some extra action (updating the current cart if exist with the customer, or getting an old existing cart...)