### PR TITLE
When the account have an empty password, we should return a :wrong_credentials message instead of raising an error

### DIFF
--- a/lib/locomotive/steam/services/auth_service.rb
+++ b/lib/locomotive/steam/services/auth_service.rb
@@ -30,7 +30,7 @@ module Locomotive
       def sign_in(options, request)
         entry = entries.all(options.type, options.id_field => options.id).first
 
-        if entry
+        if entry && entry.send(options.password_field)
           hashed_password = entry[:"#{options.password_field}_hash"]
           password        = ::BCrypt::Engine.hash_secret(options.password, entry.send(options.password_field).try(:salt))
           same_password   = secure_compare(password, hashed_password)

--- a/spec/unit/services/auth_service_spec.rb
+++ b/spec/unit/services/auth_service_spec.rb
@@ -160,6 +160,13 @@ describe Locomotive::Steam::AuthService do
       is_expected.to eq :wrong_credentials
     end
 
+
+    it "returns :wrong_credentials if the password is empty" do
+      entry = instance_double('Account', password: nil)
+      expect(entries).to receive(:all).with('accounts', { 'email' => 'john@doe.net' }).and_return([entry])
+      is_expected.to eq :wrong_credentials
+    end
+
     it "returns both :signed_in and the entry if the password matches the entry's password" do
       entry = build_account('easyone')
       expect(entries).to receive(:all).with('accounts', { 'email' => 'john@doe.net' }).and_return([entry])


### PR DESCRIPTION
Scenario:
- Create an account without setting password
- try to connect on the front with the account

excepted:
- having a message with "wrong credential"

current result:
- crash !

This patch fix the bug and with unit testing

@did 