### PR TITLE
POC have a first working version of ldap implementation

### DIFF
--- a/lib/locomotive/steam/middlewares/auth.rb
+++ b/lib/locomotive/steam/middlewares/auth.rb
@@ -11,6 +11,8 @@ module Locomotive::Steam
     # It is also in charge to load the current authenticated resource
     # from the session and put it in the liquid context.
     #
+    PROVIDER = %w(ldap)
+
     class Auth < ThreadSafe
 
       include Helpers
@@ -120,8 +122,8 @@ module Locomotive::Steam
 
       def auth_service
         provider = site.metafields[:auth_provider]
-        if provider
-          @auth_service ||= services.send("auth_#{provider[:type]}")
+        if provider && PROVIDER.include?(provider[:type])
+          @auth_service ||= services.send(:"auth_#{provider[:type]}")
         else
           @auth_service ||= services.auth
         end
@@ -129,7 +131,7 @@ module Locomotive::Steam
 
       class AuthOptions
 
-        attr_reader :site, :params, :service
+        attr_reader :site, :params
 
         def initialize(site, params)
           @site, @params = site, params

--- a/lib/locomotive/steam/services.rb
+++ b/lib/locomotive/steam/services.rb
@@ -126,6 +126,10 @@ module Locomotive
           Steam::AuthService.new(current_site, content_entry, email)
         end
 
+        register :auth_ldap do
+          Steam::AuthLdapService.new(current_site, content_entry)
+        end
+
         register :cache do
           Steam::NoCacheService.new
         end

--- a/lib/locomotive/steam/services/auth_ldap_service.rb
+++ b/lib/locomotive/steam/services/auth_ldap_service.rb
@@ -45,9 +45,9 @@ module Locomotive
         ldap.port = config['ldap_port']
         ldap.auth config['ldap_dn'], config['ldap_password']
         result = ldap.bind_as(
-          :base => config['ldap_base'],
-          :filter => "(mail=#{email})",
-          :password => password
+          base: config['ldap_base'],
+          filter: "(mail=#{email})",
+          password: password
         )
       end
 

--- a/lib/locomotive/steam/services/auth_ldap_service.rb
+++ b/lib/locomotive/steam/services/auth_ldap_service.rb
@@ -1,0 +1,66 @@
+require 'net-ldap'
+
+module Locomotive
+  module Steam
+
+    class AuthLdapService
+
+      attr_accessor_initialize :site, :entries
+
+      ACTIONS = %w(sign_in sign_out)
+
+      def valid_action?(options)
+        ACTIONS.include?(options.action)
+      end
+
+      def find_authenticated_resource(type, id)
+        entries.find(type, id)
+      end
+
+      def sign_in(options, request)
+        entry = entries.all(options.type, options.id_field => options.id).first
+        # in ldap case options.id_field must be the email
+        if entry
+          if sign_in_ldap(options.id, options.password)
+            notify(:signed_in, entry, request)
+            return [:signed_in, entry]
+          end
+        end
+
+        :wrong_credentials
+      end
+
+      def sign_out(entry, request)
+        notify(:signed_out, entry, request)
+
+        :signed_out
+      end
+
+      private
+
+      def sign_in_ldap(email, password)
+        config = site.metafields['auth_provider']
+        ldap = Net::LDAP.new
+        ldap.host = config['ldap_host']
+        ldap.port = config['ldap_port']
+        ldap.auth config['ldap_dn'], config['ldap_password']
+        result = ldap.bind_as(
+          :base => config['ldap_base'],
+          :filter => "(mail=#{email})",
+          :password => password
+        )
+      end
+
+      def notify(action, entry, request)
+        ActiveSupport::Notifications.instrument("steam.auth.#{action}",
+          site:     site,
+          entry:    entry,
+          locale:   entries.locale,
+          request:  request
+        )
+      end
+
+    end
+
+  end
+end

--- a/lib/locomotive/steam/services/auth_service.rb
+++ b/lib/locomotive/steam/services/auth_service.rb
@@ -5,8 +5,13 @@ module Locomotive
 
       MIN_PASSWORD_LENGTH   = 6
       RESET_TOKEN_LIFETIME  = 1 * 3600 # 6 hours in seconds
+      ACTIONS = %w(sign_up sign_in sign_out forgot_password reset_password)
 
       attr_accessor_initialize :site, :entries, :email_service
+
+      def valid_action?(options)
+        ACTIONS.include?(options.action)
+      end
 
       def find_authenticated_resource(type, id)
         entries.find(type, id)


### PR DESCRIPTION
Hi @did I would like to have your point of view for the ldap implementation
If you think I am going in the right direction I will continue with

- [ ] adding test
- [ ] adding an mixing for generic code between service


Note where should I put the following help for the site.yml example

For the site for adding ldap support please add the following

  auth_provider:
     type: ldap
     ldap_host: 
     ldap_port: 
     ldap_dn: 
     ldap_password: 
     ldap_base: 


