### PR TITLE
Set get cookies

### DIFF
--- a/lib/locomotive/steam/middlewares/renderer.rb
+++ b/lib/locomotive/steam/middlewares/renderer.rb
@@ -59,7 +59,8 @@ module Locomotive::Steam
           repositories:   services.repositories,
           logger:         Locomotive::Common::Logger,
           live_editing:   !!env['steam.live_editing'],
-          session:        request.session
+          session:        request.session,
+          cookies:        request.cookies
         }
       end
 

--- a/lib/locomotive/steam/services/action_service.rb
+++ b/lib/locomotive/steam/services/action_service.rb
@@ -18,6 +18,8 @@ module Locomotive
         setProp
         getSessionProp
         setSessionProp
+        getCookiesProp
+        setCookiesProp
         sendEmail
         allEntries
         findEntry
@@ -79,6 +81,14 @@ module Locomotive
 
       def set_session_prop_lambda(liquid_context)
         -> (name, value) { liquid_context.registers[:session][name.to_sym] = value }
+      end
+
+      def get_cookies_prop_lambda(liquid_context)
+        -> (name) { liquid_context.registers[:cookies][name.to_s].as_json }
+      end
+
+      def set_cookies_prop_lambda(liquid_context)
+        -> (name, value) { liquid_context.registers[:cookies][name.to_s] = value.to_s }
       end
 
       def all_entries_lambda(liquid_context)

--- a/spec/unit/services/action_service_spec.rb
+++ b/spec/unit/services/action_service_spec.rb
@@ -112,6 +112,23 @@ describe Locomotive::Steam::ActionService do
 
       end
 
+      describe 'getCookiesProp' do
+
+        let(:cookie) { { name: 'John' } }
+        let(:script) { "return getCookiesProp('name');" }
+
+        it { is_expected.to eq 'John' }
+
+      end
+
+      describe 'sendCookiesProp' do
+
+        let(:script) { "return setCookiesProp('done', true);" }
+
+        it { subject; expect(cookies[:done]).to eq true }
+
+      end
+
       describe 'allEntries' do
 
         let(:now)     { Time.use_zone('America/Chicago') { Time.zone.local(2015, 'mar', 25, 10, 0) } }


### PR DESCRIPTION
We create two new methods for dealing with the cookies inside the [liquid actions](https://locomotive-v3.readme.io/docs/introduction):

- setCookiesProp
- getCookiesProp