### PR TITLE
Fix converting an hash to a json using the filter json

### DIFF
--- a/lib/locomotive/steam/liquid/filters/json.rb
+++ b/lib/locomotive/steam/liquid/filters/json.rb
@@ -9,7 +9,9 @@ module Locomotive
               fields = fields.split(',').map(&:strip)
             end
 
-            if input.respond_to?(:each)
+            if input.is_a?(Hash)
+              object_to_json(input, fields)
+            elsif input.respond_to?(:each)
               '[' + input.map do |object|
                 fields.size == 1 ? object[fields.first].to_json : object_to_json(object, fields)
               end.join(',') + ']'

--- a/spec/unit/liquid/filters/json_spec.rb
+++ b/spec/unit/liquid/filters/json_spec.rb
@@ -54,6 +54,13 @@ describe Locomotive::Steam::Liquid::Filters::Json do
 
   end
 
+  describe '#Render Hash' do
+
+    let(:input) { [{'foo': 'bar'}] }
+    it { expect(subject).to eq %({"foo":"bar"}) }
+
+  end
+
   describe '#open_json' do
 
     let(:input) { '' }


### PR DESCRIPTION
@did I am found why the "| json" was rendering ugly stuff is shopinvader case.
Most of the time we have ruby hash as data and so the current implementation of the filter was rendering
['key1', 'foo1'], ['key2', 'foo2'] when jonify a hash like {key1: 'foo1', key2: 'foo2'}
