### PR TITLE
Fixes bug where a blank password allows login

### DIFF
--- a/lib/locomotive/steam/services/auth_service.rb
+++ b/lib/locomotive/steam/services/auth_service.rb
@@ -30,7 +30,7 @@ module Locomotive
       def sign_in(options, request)
         entry = entries.all(options.type, options.id_field => options.id).first
 
-        if entry && entry.send(options.password_field)
+        if entry && (entry.send(options.password_field).present?)
           hashed_password = entry[:"#{options.password_field}_hash"]
           password        = ::BCrypt::Engine.hash_secret(options.password, entry.send(options.password_field).try(:salt))
           same_password   = secure_compare(password, hashed_password)

--- a/spec/unit/services/auth_service_spec.rb
+++ b/spec/unit/services/auth_service_spec.rb
@@ -161,8 +161,14 @@ describe Locomotive::Steam::AuthService do
     end
 
 
-    it "returns :wrong_credentials if the password is empty" do
+    it "returns :wrong_credentials if the password is nil" do
       entry = instance_double('Account', password: nil)
+      expect(entries).to receive(:all).with('accounts', { 'email' => 'john@doe.net' }).and_return([entry])
+      is_expected.to eq :wrong_credentials
+    end
+
+    it "returns :wrong_credentials if the password is blank" do
+      entry = instance_double('Account', password: '')
       expect(entries).to receive(:all).with('accounts', { 'email' => 'john@doe.net' }).and_return([entry])
       is_expected.to eq :wrong_credentials
     end


### PR DESCRIPTION
If a password is blank instead of `nil` it can allow login.  This addresses that issue by checking for `presence`.