### PR TITLE
Fix cookie implementation and use specific cookie for lang

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,3 @@ group :test do
   gem 'codeclimate-test-reporter',  '~> 0.4.7',   require: false
   gem 'coveralls',                  '~> 0.8.1',   require: false
 end
-
-platform :ruby do
-  ruby '2.5.0'
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,8 +218,5 @@ DEPENDENCIES
   stackprof
   timecop (~> 0.9.1)
 
-RUBY VERSION
-   ruby 2.5.0p0
-
 BUNDLED WITH
    1.17.3

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ see the list in the issues section.
 
 ## Running test with docker
 
-A docker configuration is included in this repository, you can run all the test with the following process
+A docker configuration is included in this repository, you can run all the tests with the following procedure
 
 First run a bash shell inside the container
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,39 @@ see the list in the issues section.
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
 
+## Running test with docker
+
+A docker configuration is included in this repository, you can run all the test with the following process
+
+First run a bash shell inside the container
+
+```
+docker-compose run steam gosu ubuntu bash
+```
+
+Now you are inside the container you can
+
+Init the database with demo data
+
+```
+rake mongodb:test:seed
+```
+
+Run all the test with
+
+```
+rake spec
+```
+
+Run specific test with rspec
+
+```
+rspec spec/unit/middlewares/locale_spec.rb
+
+```
+
+Note: you do not need to prefix with bundle exec as the docky-ruby image already add it automatically
+
 ## License
 
 Copyright (c) 2018 NoCoffee. MIT Licensed, see MIT-LICENSE for details.

--- a/Rakefile
+++ b/Rakefile
@@ -13,17 +13,22 @@ namespace :mongodb do
     task :seed do
       root_path = File.expand_path(File.dirname(__FILE__))
       db_path   = File.join(root_path, 'spec', 'fixtures', 'mongodb')
+      if ENV['MONGO_HOST']
+        host = "--host=#{ENV['MONGO_HOST']}"
+      else
+        host = ""
+      end
 
       if database = ENV['DATABASE']
         dump_path = File.join(root_path, 'dump', database)
 
         `rm -rf #{db_path}`
-        `mongodump --db #{database}`
+        `mongodump --db #{database} #{host}`
         `mv #{dump_path} #{db_path}`
       end
 
-      `mongo steam_test_1_5_x --eval "db.dropDatabase()"`
-      `mongorestore -d steam_test_1_5_x #{db_path}`
+      `mongo steam_test_1_5_x --eval "db.dropDatabase()" #{host}`
+      `mongorestore -d steam_test_1_5_x #{db_path} #{host}`
 
       puts "Done! Update now the spec/support/helpers.rb file by setting the new id of the site returned by the mongodb_site_id method"
     end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  db:
+    image: mongo:3
+    volumes:
+      - ./data/db:/data/db
+  steam:
+    image: quay.io/akretion/docky-ruby:latest
+    environment:
+      - MONGO_HOST=db
+    volumes:
+      - .:/workspace
+      - ./bundle:/usr/local/bundle
+    depends_on:
+      - db
+version: '3'

--- a/lib/locomotive/steam/middlewares/concerns/helpers.rb
+++ b/lib/locomotive/steam/middlewares/concerns/helpers.rb
@@ -15,7 +15,7 @@ module Locomotive::Steam
 
         def render_response(content, code = 200, type = nil)
           _headers = env['steam.headers'] || {}
-
+          inject_cookies(_headers)
           @next_response = [
             code,
             { 'Content-Type' => type || 'text/html' }.merge(_headers),
@@ -28,7 +28,17 @@ module Locomotive::Steam
 
           self.log "Redirected to #{_location}".blue
 
-          @next_response = [type, { 'Content-Type' => 'text/html', 'Location' => _location }, []]
+          headers = { 'Content-Type' => 'text/html', 'Location' => _location }
+          inject_cookies(headers)
+
+          @next_response = [type, headers, []]
+        end
+
+        def inject_cookies(headers)
+          _cookies = env['steam.cookies'] || {}
+          _cookies.each do |key, vals|
+            Rack::Utils.set_cookie_header!(headers, key, vals.symbolize_keys!)
+          end
         end
 
         def modify_path(path = nil, &block)

--- a/lib/locomotive/steam/middlewares/default_env.rb
+++ b/lib/locomotive/steam/middlewares/default_env.rb
@@ -11,6 +11,7 @@ module Locomotive::Steam
         env['steam.request']        = request
         env['steam.services']       = build_services(request)
         env['steam.liquid_assigns'] = {}
+        env['steam.cookies'] = {}
 
         app.call(env)
       end

--- a/lib/locomotive/steam/services.rb
+++ b/lib/locomotive/steam/services.rb
@@ -75,7 +75,7 @@ module Locomotive
         end
 
         register :action do
-          Steam::ActionService.new(current_site, email, content_entry: content_entry, api: external_api, redirection: page_redirection)
+          Steam::ActionService.new(current_site, email, content_entry: content_entry, api: external_api, redirection: page_redirection, cookie: cookie)
         end
 
         register :content_entry do
@@ -144,6 +144,10 @@ module Locomotive
 
         register :cache do
           Steam::NoCacheService.new
+        end
+
+        register :cookie do
+          Steam::CookieService.new(request)
         end
 
         register :configuration do

--- a/lib/locomotive/steam/services/action_service.rb
+++ b/lib/locomotive/steam/services/action_service.rb
@@ -11,7 +11,7 @@ module Locomotive
 
     class ActionService
 
-      SERVICES = %w(content_entry api redirection)
+      SERVICES = %w(content_entry api redirection cookie)
 
       BUILT_IN_FUNCTIONS = %w(
         getProp
@@ -84,11 +84,11 @@ module Locomotive
       end
 
       def get_cookies_prop_lambda(liquid_context)
-        -> (name) { liquid_context.registers[:cookies][name.to_s].as_json }
+        -> (name) { cookie_service.get(name.to_s) }
       end
 
       def set_cookies_prop_lambda(liquid_context)
-        -> (name, value) { liquid_context.registers[:cookies][name.to_s] = value.to_s }
+        -> (name, values) { cookie_service.set(name.to_s, values) }
       end
 
       def all_entries_lambda(liquid_context)

--- a/lib/locomotive/steam/services/cookie_service.rb
+++ b/lib/locomotive/steam/services/cookie_service.rb
@@ -1,0 +1,25 @@
+module Locomotive
+  module Steam
+
+    class CookieService
+
+      def initialize(request)
+        @request = request
+        @cookies = request.env['steam.cookies']
+      end
+
+      def set(key, vals)
+        @cookies[key] = vals
+      end
+
+      def get(key)
+        if @cookies.include?(key)
+          @cookies[key]['value']
+        else
+          @request.cookies[key]
+        end
+      end
+
+    end
+  end
+end

--- a/spec/unit/liquid/tags/action_spec.rb
+++ b/spec/unit/liquid/tags/action_spec.rb
@@ -6,7 +6,8 @@ describe Locomotive::Steam::Liquid::Tags::Action do
   let(:source)    { '{% action "random Javascript action" %}var foo = 42; setProp("foo", foo);{% endaction %}' }
   let(:assigns)   { {} }
   let(:registers) { { services: services } }
-  let(:services)  { Locomotive::Steam::Services.build_instance }
+  let(:request)   { instance_double('Request', env: {}) }
+  let(:services)  { Locomotive::Steam::Services.build_instance(request) }
   let(:context)   { ::Liquid::Context.new(assigns, {}, registers) }
 
   before { allow(services).to receive(:current_site).and_return(site) }

--- a/spec/unit/liquid/tags/global_section_spec.rb
+++ b/spec/unit/liquid/tags/global_section_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe Locomotive::Steam::Liquid::Tags::GlobalSection do
 
-  let(:services)      { Locomotive::Steam::Services.build_instance(nil) }
+  let(:request)       { instance_double('Request', env: {}) }
+  let(:services)      { Locomotive::Steam::Services.build_instance(request) }
   let(:finder)        { services.section_finder }
   let(:source)        { 'Locomotive {% global_section header %}' }
   let(:live_editing)  { true }

--- a/spec/unit/liquid/tags/section_spec.rb
+++ b/spec/unit/liquid/tags/section_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe Locomotive::Steam::Liquid::Tags::Section do
 
-  let(:services)      { Locomotive::Steam::Services.build_instance(nil) }
+  let(:request)       { instance_double('Request', env: {}) }
+  let(:services)      { Locomotive::Steam::Services.build_instance(request) }
   let(:finder)        { services.section_finder }
   let(:source)        { 'Locomotive {% section header %}' }
   let(:live_editing)  { true }

--- a/spec/unit/liquid/tags/snippet_spec.rb
+++ b/spec/unit/liquid/tags/snippet_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe Locomotive::Steam::Liquid::Tags::Snippet do
 
-  let(:services)  { Locomotive::Steam::Services.build_instance(nil) }
+  let(:request)   { instance_double('Request', env: {}) }
+  let(:services)  { Locomotive::Steam::Services.build_instance(request) }
   let(:finder)    { services.snippet_finder }
   let(:snippet)   { instance_double('Snippet', template: nil, :template= => nil, liquid_source: 'built by NoCoffee') }
   let(:source)    { 'Locomotive {% include footer %}' }

--- a/spec/unit/middlewares/helpers_spec.rb
+++ b/spec/unit/middlewares/helpers_spec.rb
@@ -42,7 +42,11 @@ describe Locomotive::Steam::Middlewares::Concerns::Helpers do
 
     context 'mounted_on is not blank' do
 
-      before { allow(instance).to receive(:mounted_on).and_return('/my_app') }
+      before do
+        allow(instance).to receive(:mounted_on).and_return('/my_app')
+        allow(instance).to receive(:inject_cookies).and_return(nil)
+      end
+
 
       let(:location) { '/foo/bar' }
       it { is_expected.to eq '/my_app/foo/bar' }

--- a/spec/unit/middlewares/locale_spec.rb
+++ b/spec/unit/middlewares/locale_spec.rb
@@ -14,9 +14,6 @@ describe Locomotive::Steam::Middlewares::Locale do
   let(:services)        { instance_double('Services', :locale= => 'en', :cookie => cookie_service) }
   let(:middleware)      { Locomotive::Steam::Middlewares::Locale.new(app) }
   let(:accept_language) { '' }
-  let(:expected_lang)   { :de }
-  let(:expected_path)   { '/' }
-  let(:expected_cookie) { { value: expected_lang, path: '/', max_age: 1.year } }
 
   subject do
     env = env_for(
@@ -30,104 +27,97 @@ describe Locomotive::Steam::Middlewares::Locale do
     [env['steam.locale'], env['steam.path']]
   end
 
-  describe 'locale defined in the path' do
+  describe 'whatever url' do
 
-    let(:url) { 'http://models.example.com/de/hello-de/foo' }
+    let(:url) { 'http://models.example.com/whatever' }
 
-    it 'should use de language and set the cookies' do
-       expect(cookie_service).to receive(:set).with('steam-locale', expected_cookie).and_return(nil)
-       is_expected.to eq [expected_lang, '/hello-de/foo']
+    it 'should set the cookies' do
+       expect(cookie_service).to receive(:set).with('steam-locale', {
+           value: :de,
+           path: '/',
+           max_age: 1.year
+       }).and_return(nil)
+       is_expected.to eq [:de,  '/whatever']
     end
+
   end
 
-  describe 'no locale defined in the path' do
+  describe 'browse site with' do
 
-    describe 'first connexion' do
+    before { allow(cookie_service).to receive(:set).and_return(nil) }
 
-      context 'without accept-language header' do
+    describe 'locale defined in the path' do
 
-       it 'should use default language' do
-         expect(cookie_service).to receive(:set).with('steam-locale', expected_cookie).and_return(nil)
-         is_expected.to eq [expected_lang, '/']
-       end
+      let(:url) { 'http://models.example.com/de/hello-de/foo' }
 
-      end
+      it { is_expected.to eq [:de, '/hello-de/foo'] }
 
-      context 'with accept-language header' do
+    end
 
-        let(:accept_language) { 'fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7' }
-        let(:expected_lang) { :fr }
+    describe 'no locale defined in the path' do
 
-        it 'should use "fr" in header' do
-          expect(cookie_service).to receive(:set).with('steam-locale', expected_cookie).and_return(nil)
-          is_expected.to eq [expected_lang,  '/']
+      describe 'first connexion' do
+
+        context 'without accept-language header' do
+
+          it { is_expected.to eq [:de, '/'] }
+
         end
 
-        context 'with url path' do
+        context 'with accept-language header' do
 
-          let(:url) { 'http://models.example.com/werkzeug' }
-          let(:expected_lang) { :de }
+          let(:accept_language) { 'fr-FR,fr;q=0.9,en-US;q=0.8,en;q=0.7' }
 
-          it 'should use "de" in path' do
-            expect(cookie_service).to receive(:set).with('steam-locale', expected_cookie).and_return(nil)
-            is_expected.to eq [expected_lang, '/werkzeug']
+          it { is_expected.to eq [:fr,  '/'] }
+
+          context 'with url path' do
+
+            let(:url) { 'http://models.example.com/werkzeug' }
+
+            it { is_expected.to eq [:de, '/werkzeug'] }
+
           end
 
         end
 
       end
 
-    end
+      context 'user with cookie, use it' do
 
-    context 'user with cookie, use it' do
+        let(:cookie_lang) { 'en' }
 
-      let(:cookie_lang) { 'en' }
-      let(:expected_lang) { :en }
+        it { is_expected.to eq [:en, '/'] }
 
-      it 'should use "en" in cookie' do
-        expect(cookie_service).to receive(:set).with('steam-locale', expected_cookie).and_return(nil)
-        is_expected.to eq [expected_lang, '/']
       end
 
     end
 
-  end
+    describe 'locale asked in the request params' do
 
-  describe 'locale asked in the request params' do
+      context 'the locale is blank' do
 
-    context 'the locale is blank' do
+        let(:url) { 'http://models.example.com?locale=' }
 
-      let(:url) { 'http://models.example.com?locale=' }
+        it { is_expected.to eq [:de, '/'] }
 
-      it 'should use default locale "de"' do
-        expect(cookie_service).to receive(:set).with('steam-locale', expected_cookie).and_return(nil)
-        is_expected.to eq [expected_lang, '/']
+      end
+
+      context 'the locale exists' do
+
+        let(:url) { 'http://models.example.com?locale=en' }
+
+        it { is_expected.to eq [:en, '/'] }
+
+      end
+
+      context 'the locale is unknown' do
+
+        let(:url) { 'http://models.example.com?locale=onload' }
+
+        it { is_expected.to eq [:de, '/'] }
+
       end
 
     end
-
-    context 'the locale exists' do
-
-      let(:url) { 'http://models.example.com?locale=en' }
-      let(:expected_lang) { :en }
-
-      it 'should use existing locale "en"' do
-        expect(cookie_service).to receive(:set).with('steam-locale', expected_cookie).and_return(nil)
-        is_expected.to eq [expected_lang, '/']
-      end
-
-    end
-
-    context 'the locale is unknown' do
-
-      let(:url) { 'http://models.example.com?locale=onload' }
-
-      it 'should use default locale "de"' do
-        expect(cookie_service).to receive(:set).with('steam-locale', expected_cookie).and_return(nil)
-        is_expected.to eq [expected_lang, '/']
-      end
-
-    end
-
   end
 end

--- a/spec/unit/services/action_service_spec.rb
+++ b/spec/unit/services/action_service_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe Locomotive::Steam::ActionService do
 
-  let(:site_hash)     { { 'name' => 'Acme Corp' } }
-  let(:site)          { instance_double('Site', as_json: site_hash ) }
-  let(:email_service) { instance_double('EmailService') }
-  let(:entry_service) { instance_double('ContentService') }
-  let(:api_service)   { instance_double('ExternalAPIService') }
+  let(:site_hash)      { { 'name' => 'Acme Corp' } }
+  let(:site)           { instance_double('Site', as_json: site_hash ) }
+  let(:email_service)  { instance_double('EmailService') }
+  let(:entry_service)  { instance_double('ContentService') }
+  let(:api_service)    { instance_double('ExternalAPIService') }
   let(:redirection_service) { instance_double('PageRedirectionService') }
   let(:cookie_service) { instance_double('CookieService') }
-  let(:service)       { described_class.new(site, email_service, content_entry: entry_service, api: api_service, redirection: redirection_service, cookie: cookie_service) }
+  let(:service)        { described_class.new(site, email_service, content_entry: entry_service, api: api_service, redirection: redirection_service, cookie: cookie_service) }
 
   describe '#run' do
 
@@ -115,19 +115,25 @@ describe Locomotive::Steam::ActionService do
       end
 
       describe 'getCookiesProp' do
+
         let(:script) { "return getCookiesProp('name');" }
-        before do
+
+        it 'should read in the cookie name and return John' do
           expect(cookie_service).to receive(:get).with('name').and_return('John')
+          is_expected.to eq('John')
         end
-        it { is_expected.to eq('John') }
+
       end
 
       describe 'setCookiesProp' do
+
         let(:script) { "return setCookiesProp('done', {'value': true});" }
-        before do
+
+        it 'should set the cookie done with the value true' do
           expect(cookie_service).to receive(:set).with('done', {'value' => true})
+          is_expected.to eq(nil)
         end
-        it { is_expected.to eq(nil) }
+
       end
 
       describe 'allEntries' do

--- a/spec/unit/services/action_service_spec.rb
+++ b/spec/unit/services/action_service_spec.rb
@@ -8,7 +8,8 @@ describe Locomotive::Steam::ActionService do
   let(:entry_service) { instance_double('ContentService') }
   let(:api_service)   { instance_double('ExternalAPIService') }
   let(:redirection_service) { instance_double('PageRedirectionService') }
-  let(:service)       { described_class.new(site, email_service, content_entry: entry_service, api: api_service, redirection: redirection_service) }
+  let(:cookie_service) { instance_double('CookieService') }
+  let(:service)       { described_class.new(site, email_service, content_entry: entry_service, api: api_service, redirection: redirection_service, cookie: cookie_service) }
 
   describe '#run' do
 
@@ -114,20 +115,19 @@ describe Locomotive::Steam::ActionService do
       end
 
       describe 'getCookiesProp' do
-
-        let(:cookies) { { 'name' => 'John' } }
         let(:script) { "return getCookiesProp('name');" }
-
-        it { is_expected.to eq 'John' }
-
+        before do
+          expect(cookie_service).to receive(:get).with('name').and_return('John')
+        end
+        it { is_expected.to eq('John') }
       end
 
-      describe 'sendCookiesProp' do
-
-        let(:script) { "return setCookiesProp('done', true);" }
-
-        it { subject; expect(cookies['done']).to eq 'true' }
-
+      describe 'setCookiesProp' do
+        let(:script) { "return setCookiesProp('done', {'value': true});" }
+        before do
+          expect(cookie_service).to receive(:set).with('done', {'value' => true})
+        end
+        it { is_expected.to eq(nil) }
       end
 
       describe 'allEntries' do

--- a/spec/unit/services/cookie_service_spec.rb
+++ b/spec/unit/services/cookie_service_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe Locomotive::Steam::CookieService do
+
+  let(:steam_cookies)   { {} }
+  let(:request_cookies) { {} }
+  let(:request)         { instance_double('Request', env: { 'steam.cookies' => steam_cookies }, cookies: request_cookies) }
+  let(:cookie)          { {'value' => 'bar2'} }
+  let(:service)   { described_class.new(request)}
+
+  describe '#get cookies from request' do
+
+    let(:request_cookies) { {'foo' => 'bar'} }
+    subject { service.get('foo') }
+
+    context 'from request' do
+      it { is_expected.to eq 'bar' }
+    end
+
+    context 'from response' do
+      let(:steam_cookies) { {'foo' => {'value' => 'bar2'}} }
+      it { is_expected.to eq 'bar2' }
+    end
+
+  end
+
+  describe '#set cookies from response' do
+
+    subject { service.set('foo', cookie) }
+
+    it 'set the cookies into steam' do
+      is_expected.to eq cookie
+      expect(steam_cookies).to eq({'foo' => cookie})
+    end
+
+  end
+
+end

--- a/spec/unit/services/cookie_service_spec.rb
+++ b/spec/unit/services/cookie_service_spec.rb
@@ -6,7 +6,7 @@ describe Locomotive::Steam::CookieService do
   let(:request_cookies) { {} }
   let(:request)         { instance_double('Request', env: { 'steam.cookies' => steam_cookies }, cookies: request_cookies) }
   let(:cookie)          { {'value' => 'bar2'} }
-  let(:service)   { described_class.new(request)}
+  let(:service)         { described_class.new(request)}
 
   describe '#get cookies from request' do
 


### PR DESCRIPTION
Fix the current implementation for getting and setting the cookie. The
set method was not working. Add a new steam variable 'steam.cookies'
that can be extended in your custom gem to add aditionnal cookies
Change the way to store the selected lang. Instead of storing the
information in the main cookie, use a dedicated cookie.
This allow caching with external tools like varnish.
Adapt the test regarding this change
Add a docker configuration to run the test easily