### PR TITLE
Implementation of recaptcha

### DIFF
--- a/lib/locomotive/steam/middlewares/auth.rb
+++ b/lib/locomotive/steam/middlewares/auth.rb
@@ -14,6 +14,7 @@ module Locomotive::Steam
     class Auth < ThreadSafe
 
       include Concerns::Helpers
+      include Concerns::Recaptcha
 
       def _call
         load_authenticated_entry
@@ -29,6 +30,7 @@ module Locomotive::Steam
 
       def sign_up(options)
         return if authenticated?
+        return unless recaptcha_content_entry_valid?(options.type, options.recaptcha_response)
 
         status, entry = services.auth.sign_up(options, default_liquid_context, request)
 
@@ -190,6 +192,10 @@ module Locomotive::Steam
 
         def smtp_config
           @config ||= _read_smtp_config
+        end
+
+        def recaptcha_response
+          params["g-recaptcha-response"]
         end
 
         def smtp

--- a/lib/locomotive/steam/middlewares/concerns/recaptcha.rb
+++ b/lib/locomotive/steam/middlewares/concerns/recaptcha.rb
@@ -1,0 +1,39 @@
+module Locomotive::Steam
+  module Middlewares
+    module Concerns
+      module Recaptcha
+
+        def recaptcha_content_entry_valid?(slug, response)
+          !recaptcha_content_entry_required?(slug) || recaptcha_valid?(response)
+        end
+
+        def recaptcha_content_entry_required?(slug)
+          type = content_entry.get_type(slug)
+          # TODO @did we should remove this try when data will be updated?
+          !type.nil? && type.try(:recaptcha_required)
+        end
+
+        def recaptcha_valid?(response)
+          valid = recaptcha.verify(response)
+          liquid_assigns['recaptcha_invalid'] = !valid
+          valid
+        end
+
+        def recaptcha
+          services.recaptcha
+        end
+
+        def build_invalid_recaptcha_entry(slug, entry_attributes)
+          entry = content_entry.build(slug, entry_attributes)
+          entry.errors.add(:recaptcha_invalid, true)
+          entry
+        end
+
+        def content_entry
+          services.content_entry
+        end
+
+      end
+    end
+  end
+end

--- a/lib/locomotive/steam/middlewares/entry_submission.rb
+++ b/lib/locomotive/steam/middlewares/entry_submission.rb
@@ -6,6 +6,7 @@ module Locomotive::Steam
     class EntrySubmission < ThreadSafe
 
       include Concerns::Helpers
+      include Concerns::Recaptcha
 
       HTTP_REGEXP             = /^https?:\/\//o
       ENTRY_SUBMISSION_REGEXP = /^\/entry_submissions\/(\w+)/o
@@ -141,7 +142,9 @@ module Locomotive::Steam
       #
       #
       def create_entry(slug)
-        if entry = entry_submission.submit(slug, entry_attributes)
+        if not recaptcha_content_entry_valid?(slug, entry_attributes["g-recaptcha-response"])
+          build_invalid_recaptcha_entry(slug, entry_attributes)
+        elsif entry = entry_submission.submit(slug, entry_attributes)
           entry
         else
           raise %{Unknown content type "#{slug}" or public_submission_enabled property not true}

--- a/lib/locomotive/steam/services.rb
+++ b/lib/locomotive/steam/services.rb
@@ -142,6 +142,10 @@ module Locomotive
           Steam::AuthService.new(current_site, content_entry, email)
         end
 
+        register :recaptcha do
+          Steam::RecaptchaService.new(request, current_site)
+        end
+
         register :cache do
           Steam::NoCacheService.new
         end

--- a/lib/locomotive/steam/services/content_entry_service.rb
+++ b/lib/locomotive/steam/services/content_entry_service.rb
@@ -24,6 +24,16 @@ module Locomotive
         end
       end
 
+      def build(type_slug, attributes)
+        with_repository(type_slug) do |_repository|
+          _attributes = prepare_attributes(_repository.content_type, attributes)
+
+          entry = _repository.build(_attributes)
+
+          i18n_decorate { entry }
+        end
+      end
+
       # Warning: do not work with localized and file fields
       def create(type_slug, attributes, as_json = false)
         with_repository(type_slug) do |_repository|

--- a/lib/locomotive/steam/services/recaptcha_service.rb
+++ b/lib/locomotive/steam/services/recaptcha_service.rb
@@ -1,0 +1,27 @@
+require 'httparty'
+
+module Locomotive
+  module Steam
+
+    class RecaptchaService
+
+      def initialize(request, site)
+        # This service support google recaptcha or API compatible
+        @api = site.metafields.dig(:google, :recaptcha_api) || 'https://www.google.com/recaptcha/api/siteverify'
+        @secret = site.metafields.dig(:google, :recaptcha_secret)
+        @request = request
+      end
+
+      def verify(response)
+        res = HTTParty.get(@api, { query: {
+            secret: @secret,
+            response: response,
+            remoteip: @request.ip,
+        }})
+        res.parsed_response["success"]
+      end
+
+    end
+
+  end
+end

--- a/spec/unit/middlewares/auth_spec.rb
+++ b/spec/unit/middlewares/auth_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 require_relative '../../../lib/locomotive/steam/middlewares/thread_safe'
 require_relative '../../../lib/locomotive/steam/middlewares/concerns/helpers'
+require_relative '../../../lib/locomotive/steam/middlewares/concerns/recaptcha'
 require_relative '../../../lib/locomotive/steam/middlewares/auth'
 
 describe Locomotive::Steam::Middlewares::Auth::AuthOptions do

--- a/spec/unit/middlewares/entry_submission_spec.rb
+++ b/spec/unit/middlewares/entry_submission_spec.rb
@@ -2,51 +2,80 @@ require 'spec_helper'
 
 require_relative '../../../lib/locomotive/steam/middlewares/thread_safe'
 require_relative '../../../lib/locomotive/steam/middlewares/concerns/helpers'
+require_relative '../../../lib/locomotive/steam/middlewares/concerns/recaptcha'
 require_relative '../../../lib/locomotive/steam/middlewares/entry_submission'
 
 describe Locomotive::Steam::Middlewares::EntrySubmission do
 
-  let(:app)         { ->(env) { [200, env, ['app']] } }
-  let(:site)        { instance_double('Site', default_locale: 'en', locales: ['en']) }
-  let(:middleware)  { described_class.new(app) }
-  let(:service)     { instance_double('EntrySubmission') }
-  let(:services)    { instance_double('Services', entry_submission: service, :locale= => 'en') }
-  let(:session)     { {} }
-  let(:method)      { 'POST' }
+  let(:app)                { ->(env) { [200, env, ['app']] } }
+  let(:site)               { instance_double('Site', default_locale: 'en', locales: ['en']) }
+  let(:middleware)         { described_class.new(app) }
+  let(:service)            { instance_double('EntrySubmission') }
+  let(:recaptcha)          { instance_double('Recaptcha') }
+  let(:services)           { instance_double('Services', entry_submission: service, recaptcha: recaptcha, :locale= => 'en') }
+  let(:session)            { {} }
+  let(:method)             { 'POST' }
+  let(:valid_recaptcha)    { true }
+  let(:errors)             { instance_double('Error', empty?: false) }
+  let(:entry)              { instance_double('Entry', errors: errors, content_type_slug: 'contacts') }
+  let(:form)               { { content_type_slug: 'contacts', content: { email: 'john@doe.net' } } }
 
   before do
     allow_any_instance_of(described_class).to receive(:csrf_field).and_return('csrf_field')
+    allow_any_instance_of(described_class).to receive(:recaptcha_content_entry_valid?).and_return(valid_recaptcha)
   end
 
   describe '#call' do
 
     let(:rack_env) { build_env }
 
-    before do
-      expect(service).to receive(:submit).with('contacts', { email: 'john@doe.net' }).and_return(entry)
+    subject do
+      code, env = middleware.call(rack_env)
+      [code, env['steam.liquid_assigns']['contact']]
     end
 
-    subject { middleware.call(rack_env) }
 
-    context 'the creation of a content entry returns nil' do
+    context 'with valid recaptcha' do
 
-      let(:form)  { { content_type_slug: 'contacts', content: { email: 'john@doe.net' } } }
-      let(:entry) { nil }
-
-      it 'raises an exception' do
-        expect { subject }.to raise_exception('Unknown content type "contacts" or public_submission_enabled property not true')
+      before do
+        expect(service).to receive(:submit).with('contacts', { email: 'john@doe.net' }).and_return(entry)
       end
 
+      context 'the creation of a content entry returns nil' do
+
+        let(:entry) { nil }
+
+        it 'raises an exception' do
+          expect { subject }.to raise_exception('Unknown content type "contacts" or public_submission_enabled property not true')
+        end
+      end
     end
 
+    context 'with invalid recaptcha' do
+
+      before do
+        expect_any_instance_of(described_class).to receive(:build_invalid_recaptcha_entry).with('contacts', { email: 'john@doe.net' }).and_return(entry)
+      end
+
+      context 'the creation of a content entry is skip' do
+
+        let(:valid_recaptcha)    { false }
+
+        it 'should return a 200 with the invalid entry' do
+          expect(subject).to eq [200, entry]
+        end
+
+      end
+    end
   end
 
   def build_env
     env_for('http://example.com/contact-us', params: form, method: method).tap do |env|
-      env['steam.request']    = Rack::Request.new(env)
-      env['steam.site']       = site
-      env['steam.services']   = services
-      env['rack.session']     = session
+      env['steam.request']        = Rack::Request.new(env)
+      env['steam.site']           = site
+      env['steam.services']       = services
+      env['rack.session']         = session
+      env['steam.liquid_assigns'] = {}
     end
   end
 


### PR DESCRIPTION
This PR add the recaptcha support.
On the content entry we can define a new field "recaptcha_required", need change in locomotive
- [x] https://github.com/locomotivecms/engine/pull/1278
- [ ] we need to update the scalfolding in wagon
- [x] @did  we need to regenerated the demo database in order to have content type with the field "recaptcha_required" so I can remove my "try" https://github.com/locomotivecms/steam/pull/133/commits/351e33972eedfa5e75440da4d660dff9d6b72256#diff-a40b4148cb5be90ed45deaf8706e3d72R13

How to use/test it:
- you need to use the branch on my PR on the steam and engine
- you need to add the property : recaptcha_required: true on you content_type.yml

- in your metafields_schema.yml you need to add the key "recaptcha_site_key" and "recaptcha_secret" (then the value in your site.yml)

```
google:
  label: Google API Integration
  fields:
    recaptcha_site_key:
      hint: reCAPTCHA - Site key
      type: string
    recaptcha_secret:
      hint: reCAPTCHA - Secret key
      type: string
```

An example of implementation on our public shopinvader theme have been done here
https://github.com/akretion/shopinvader-template/pull/13/files

Not in this example we add the recaptcha on the sign_up authentification. It also work on simple public submission.
