### PR TITLE
[FIX] sign out should do a redirect to avoid tricky case

### DIFF
--- a/lib/locomotive/steam/middlewares/auth.rb
+++ b/lib/locomotive/steam/middlewares/auth.rb
@@ -62,6 +62,8 @@ module Locomotive::Steam
 
         store_authenticated(nil)
 
+        redirect_to options.callback || path
+
         append_message(:signed_out)
       end
 

--- a/spec/integration/server/auth_spec.rb
+++ b/spec/integration/server/auth_spec.rb
@@ -152,9 +152,16 @@ describe 'Authentication' do
       'authenticated_entry_id'    => 'john'
     } }
 
+    it 'redirect to the requested page' do
+      post '/account/sign-in', params, { 'rack.session' => rack_session }
+      expect(last_response.status).to eq 301
+      expect(last_response.location).to eq "/account/sign-in"
+    end
+
     it 'displays the profile page as described in the params' do
       post '/account/sign-in', params, { 'rack.session' => rack_session }
-      expect(last_response.body).to include "You've been signed out"
+      follow_redirect!
+      expect(last_response.body).to include "Sign in"
       expect(last_response.body).not_to include "You're already authenticated!"
     end
 


### PR DESCRIPTION
In plugin when one of the service registred already have keep in memory the information of the person logged.
By doing a redirect we are sure to build a page without information that depend of the current sign out user.

For example in shopinvader plugin, the information user are still here during the rendering of the page.

@did we should discuss if it the right solution