### PR TITLE
Fix metafields `sample` key precendence

### DIFF
--- a/lib/locomotive/steam/adapters/filesystem/sanitizers/site.rb
+++ b/lib/locomotive/steam/adapters/filesystem/sanitizers/site.rb
@@ -49,7 +49,7 @@ module Locomotive::Steam
 
                 entity.metafields ||= {}
                 entity.metafields[namespace[:name]] ||= {}
-                entity.metafields[namespace[:name]][field[:name]] = field[:sample]
+                entity.metafields[namespace[:name]][field[:name]] ||= field[:sample]
               end
             end
           end


### PR DESCRIPTION
Fixes bug reported in https://github.com/locomotivecms/engine/issues/1298