### PR TITLE
[WIP] Add Support for pre-defined Custom Setting Types

### DIFF
--- a/lib/locomotive/steam/adapters/filesystem.rb
+++ b/lib/locomotive/steam/adapters/filesystem.rb
@@ -122,9 +122,9 @@ module Locomotive::Steam
     end
 
     def build_sanitizers
-      hash = Hash.new { build_klass('Sanitizers', :simple).new }
+      hash = Hash.new { build_klass('Sanitizers', :simple).new(site_path) }
       %i(sites pages content_types content_entries snippets sections).inject(hash) do |memo, name|
-        memo[name] = build_klass('Sanitizers', name).new
+        memo[name] = build_klass('Sanitizers', name).new(site_path)
         memo
       end
     end

--- a/lib/locomotive/steam/adapters/filesystem/sanitizers/section.rb
+++ b/lib/locomotive/steam/adapters/filesystem/sanitizers/section.rb
@@ -41,6 +41,39 @@ module Locomotive::Steam
               definition['default'] = default
             end
 
+            # Handle Custom Setting Types
+            custom_field_types = load_custom_field_types
+
+            if custom_field_types.present?
+              if definition['settings'].present?
+                definition['settings'].each_with_index do |setting, i|
+                  if setting['type'].present?
+                    custom_field_type = custom_field_types.detect{|x| x[:slug] == setting['type']}
+
+                    if custom_field_type
+                      definition['settings'][i] = custom_field_type[:definition].merge(setting)
+                    end
+                  end
+                end
+              end
+
+              if definition['blocks'].present?
+                definition['blocks'].each_with_index do |block_def, i|
+                  if block_def['settings'].present?
+                    block_def['settings'].each_with_index do |setting, i2|
+                      if setting['type'].present?
+                        custom_field_type = custom_field_types.detect{|x| x[:slug] == setting['type']}
+
+                        if custom_field_type
+                          definition['blocks'][i]['settings'][i2] = custom_field_type[:definition].merge(setting)
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+            end
+
             definition
           end
 

--- a/lib/locomotive/steam/adapters/filesystem/sanitizers/site.rb
+++ b/lib/locomotive/steam/adapters/filesystem/sanitizers/site.rb
@@ -30,6 +30,8 @@ module Locomotive::Steam
           end
 
           def parse_metafields(fields)
+            custom_field_types = load_custom_field_types
+
             fields.each_with_index.map do |(name, attributes), position|
               name, attributes = name.to_a[0] if name.is_a?(Hash) # ordered list of fields
 
@@ -38,7 +40,17 @@ module Locomotive::Steam
                 attributes[:hint]   = { default: attributes[:hint] } if attributes[:hint].is_a?(String)
               end
 
-              { name: name.to_s, position: position }.merge(attributes || {})
+              attributes ||= {}
+
+              if custom_field_types.present? && attributes[:type].present?
+                custom_field_type = custom_field_types.detect{|x| x[:slug] == attributes[:type]}
+
+                if custom_field_type
+                  attributes = custom_field_type[:definition].merge(attributes)
+                end
+              end
+
+              { name: name.to_s, position: position }.merge(attributes)
             end
           end
 


### PR DESCRIPTION
Solves feature request within https://github.com/locomotivecms/engine/issues/1277#issuecomment-482546151

TBD:

- Deploy fails for Content Type which utilize a custom field type
  - `Resource invalid: entries_custom_fields is invalid, #5d00127ee1382349794fe075: Type is not included in the list`
- Section & Site Metafields editors fail to load when custom field type is used

I will be needing some assistance to complete this feature as so far I am only familiar with the Filesystem adapters. 

Please feel free to refractor as necessary.

Related PR's:
- Wagon: 
- Engine: