### PR TITLE
Utilize global defaults for dropzone preset when `use_default` is defined

### DIFF
--- a/lib/locomotive/steam/adapters/filesystem/sanitizers/section.rb
+++ b/lib/locomotive/steam/adapters/filesystem/sanitizers/section.rb
@@ -41,6 +41,26 @@ module Locomotive::Steam
               definition['default'] = default
             end
 
+            # Utilize global defaults for dropzone preset when `use_default` is defined
+            if definition.key?('default') && definition.key?('dropzone_presets')
+              definition['dropzone_presets'].each_with_index do |preset_def, i|
+                if preset_def['use_default']
+                  # Fallback to use setting `default` key for Standalone/Global section settings and block settings
+                  definition['default']['settings'].each do |k,v|
+                    if !preset_def['settings'].key?(k)
+                      definition['dropzone_presets'][i]['settings'][setting['id']] = v
+                    end
+                  end
+
+                  preset_def['blocks'] ||= []
+                  definition['default']['blocks'] ||= []
+
+                  definition['dropzone_presets'][i]['blocks'] = preset_def['blocks'] + definition['default']['blocks']
+                end
+              end
+            end
+
+
             definition
           end
 


### PR DESCRIPTION
Solves https://github.com/locomotivecms/engine/issues/1335