### PR TITLE
[FIX] Allows to get JSON request to params

### DIFF
--- a/lib/locomotive/steam/middlewares/thread_safe.rb
+++ b/lib/locomotive/steam/middlewares/thread_safe.rb
@@ -58,7 +58,7 @@ module Locomotive::Steam::Middlewares
     end
 
     def params
-      @params ||= if (request.content_type && request.content_type.start_with?('application/json')) && (request.post? || request.put?)
+      @params ||= if request.content_type&.start_with?('application/json') && (request.post? || request.put?)
         request.body.rewind
         JSON.parse(request.body.read).with_indifferent_access
       else

--- a/lib/locomotive/steam/middlewares/thread_safe.rb
+++ b/lib/locomotive/steam/middlewares/thread_safe.rb
@@ -58,7 +58,7 @@ module Locomotive::Steam::Middlewares
     end
 
     def params
-      @params ||= if request.content_type == 'application/json' && (request.post? || request.put?)
+      @params ||= if (request.content_type && request.content_type.start_with?('application/json')) && (request.post? || request.put?)
         request.body.rewind
         JSON.parse(request.body.read).with_indifferent_access
       else


### PR DESCRIPTION
As header Content-Type can contain options like charset
and/or boundary as further arguments, test for
application/json at the beginning of the string.

e.g. : 'Content-Type: application/json; charset=utf-8'