### PR TITLE
[FIX] only log params when running wagon

### DIFF
--- a/lib/locomotive/steam/middlewares/logging.rb
+++ b/lib/locomotive/steam/middlewares/logging.rb
@@ -13,7 +13,10 @@ module Locomotive::Steam
         now = Time.now
 
         log "Started #{env['REQUEST_METHOD'].upcase} \"#{env['PATH_INFO']}\" at #{now}".light_white, 0
-        log "Params: #{env.fetch('steam.request').params.inspect}"
+
+        if Locomotive::Steam.configuration.mode == :test
+          log "Params: #{env.fetch('steam.request').params.inspect}"
+        end
 
         app.call(env).tap do |response|
           done_in_ms = ((Time.now - now) * 10000).truncate / 10.0


### PR DESCRIPTION
Only log params when running wagon, this avoid leaking information in log in production