### PR TITLE
Deprecated usage of Object#=~ might cause pbms with Mongo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_script: ./script/ci/before_build.sh
 rvm:
   - 2.6.1
   - 2.6.5
-  - 2.7.1
+  - 2.7.2
 env:
   - CODECLIMATE_REPO_TOKEN=3fa74f2ade25037fccd7261090acbdeae232639c3a83aafb80ee428ec16b8cf9
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ before_script: ./script/ci/before_build.sh
 rvm:
   - 2.6.1
   - 2.6.5
+  - 2.7.1
 env:
   - CODECLIMATE_REPO_TOKEN=3fa74f2ade25037fccd7261090acbdeae232639c3a83aafb80ee428ec16b8cf9
 addons:

--- a/lib/locomotive/steam/adapters/filesystem/sanitizers/content_entry.rb
+++ b/lib/locomotive/steam/adapters/filesystem/sanitizers/content_entry.rb
@@ -53,7 +53,7 @@ module Locomotive::Steam
 
           def set_id(entity)
             # don't override the id if it was set from a MongoDB dump
-            return if entity._id =~ /[a-z0-9]{12,}/
+            return if entity._id.to_s =~ /[a-z0-9]{12,}/
 
             if (slug = entity[:_slug]).respond_to?(:translations)
               entity[:_id] = slug[locale]

--- a/lib/locomotive/steam/liquid/tags/concerns/path.rb
+++ b/lib/locomotive/steam/liquid/tags/concerns/path.rb
@@ -29,7 +29,7 @@ module Locomotive
               handle = @context[@handle] || @handle
 
               # is external url?
-              if handle =~ Locomotive::Steam::IsHTTP
+              if handle.to_s =~ Locomotive::Steam::IsHTTP
                 handle
               elsif page = self.retrieve_page_drop_from_handle(handle) # return a drop or model?
                 # make sure we've got the page/content entry (if templatized)

--- a/lib/locomotive/steam/services/asset_host_service.rb
+++ b/lib/locomotive/steam/services/asset_host_service.rb
@@ -14,7 +14,7 @@ module Locomotive
 
         timestamp ||= (site.try(:template_version) || site.try(:updated_at)).to_i
 
-        return add_timestamp_suffix(source, timestamp) if source =~ Steam::IsHTTP
+        return add_timestamp_suffix(source, timestamp) if source.to_s =~ Steam::IsHTTP
 
         url = self.host ? build_url(host, source) : source
 


### PR DESCRIPTION

My local tests fail, need to make the PR to see what Travis says.

That said, seems a necessary fix for Ruby 2.7.*