### PR TITLE
Robert/ruby27/mime types update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_script: ./script/ci/before_build.sh
 rvm:
   - 2.6.1
   - 2.6.5
-  - 2.7.1
+  - 2.7.2
 env:
   - CODECLIMATE_REPO_TOKEN=3fa74f2ade25037fccd7261090acbdeae232639c3a83aafb80ee428ec16b8cf9
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ before_script: ./script/ci/before_build.sh
 rvm:
   - 2.6.1
   - 2.6.5
+  - 2.7.1
 env:
   - CODECLIMATE_REPO_TOKEN=3fa74f2ade25037fccd7261090acbdeae232639c3a83aafb80ee428ec16b8cf9
 addons:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ PATH
       kramdown (~> 2.3.0)
       liquid (~> 4.0.3)
       locomotivecms_common (~> 0.4.0)
-      mime-types (~> 3.1.0)
+      mime-types (~> 3.3.0)
       mimetype-fu (~> 0.1.2)
       moneta (~> 1.0.0)
       morphine (~> 0.1.1)
@@ -44,9 +44,9 @@ GEM
     autoprefixer-rails (8.0.0)
       execjs
     bcrypt (3.1.16)
-    bson (4.10.1)
+    bson (4.11.1)
     chronic (0.10.2)
-    chunky_png (1.3.12)
+    chunky_png (1.3.14)
     codeclimate-test-reporter (0.4.8)
       simplecov (>= 0.7.1, < 1.0.0)
     coffee-script (2.4.1)
@@ -111,9 +111,9 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     memory_profiler (0.9.14)
-    mime-types (3.1)
+    mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.0512)
+    mime-types-data (3.2020.1104)
     mimetype-fu (0.1.2)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
@@ -133,7 +133,7 @@ GEM
     pony (1.13.1)
       mail (>= 2.0)
     public_suffix (4.0.6)
-    puma (5.0.2)
+    puma (5.0.4)
       nio4r (~> 2.0)
     rack (2.2.3)
     rack-cache (1.7.2)
@@ -176,7 +176,7 @@ GEM
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    stackprof (0.2.15)
+    stackprof (0.2.16)
     stringex (2.8.5)
     sync (0.5.0)
     temple (0.8.2)
@@ -188,7 +188,7 @@ GEM
     timecop (0.9.2)
     tins (1.26.0)
       sync
-    tzinfo (1.2.7)
+    tzinfo (1.2.8)
       thread_safe (~> 0.1)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
@@ -216,4 +216,4 @@ DEPENDENCIES
   timecop (~> 0.9.1)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/lib/locomotive/steam/adapters/filesystem/sanitizers/content_entry.rb
+++ b/lib/locomotive/steam/adapters/filesystem/sanitizers/content_entry.rb
@@ -53,7 +53,7 @@ module Locomotive::Steam
 
           def set_id(entity)
             # don't override the id if it was set from a MongoDB dump
-            return if entity._id =~ /[a-z0-9]{12,}/
+            return if entity._id.to_s =~ /[a-z0-9]{12,}/
 
             if (slug = entity[:_slug]).respond_to?(:translations)
               entity[:_id] = slug[locale]

--- a/lib/locomotive/steam/liquid/tags/concerns/path.rb
+++ b/lib/locomotive/steam/liquid/tags/concerns/path.rb
@@ -29,7 +29,7 @@ module Locomotive
               handle = @context[@handle] || @handle
 
               # is external url?
-              if handle =~ Locomotive::Steam::IsHTTP
+              if handle.to_s =~ Locomotive::Steam::IsHTTP
                 handle
               elsif page = self.retrieve_page_drop_from_handle(handle) # return a drop or model?
                 # make sure we've got the page/content entry (if templatized)

--- a/lib/locomotive/steam/services/asset_host_service.rb
+++ b/lib/locomotive/steam/services/asset_host_service.rb
@@ -14,7 +14,7 @@ module Locomotive
 
         timestamp ||= (site.try(:template_version) || site.try(:updated_at)).to_i
 
-        return add_timestamp_suffix(source, timestamp) if source =~ Steam::IsHTTP
+        return add_timestamp_suffix(source, timestamp) if source.to_s =~ Steam::IsHTTP
 
         url = self.host ? build_url(host, source) : source
 

--- a/locomotivecms_steam.gemspec
+++ b/locomotivecms_steam.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'kramdown',               '~> 2.3.0'
   spec.add_dependency 'RedCloth',               '~> 4.3.2'
   spec.add_dependency 'mimetype-fu',            '~> 0.1.2'
-  spec.add_dependency 'mime-types',             '~> 3.1.0'
+  spec.add_dependency 'mime-types',             '~> 3.3.0'
   spec.add_dependency 'duktape',                '~> 2.0.1.1'
   spec.add_dependency 'pony',                   '~> 1.12'
 


### PR DESCRIPTION
This will get rid of the usage of `_<n>` variables in `mime-type`, which are, of course, automatically provided block arguments in Ruby 2.7