### PR TITLE
Make the recaptcha minimum acceptable score configurable

### DIFF
--- a/lib/locomotive/steam/services/recaptcha_service.rb
+++ b/lib/locomotive/steam/services/recaptcha_service.rb
@@ -7,13 +7,15 @@ module Locomotive
     class RecaptchaService
 
       GOOGLE_API_URL = 'https://www.google.com/recaptcha/api/siteverify'.freeze
+      MIN_SCORE = 0.2
 
       def initialize(site, request)
         attributes = site.metafields.values.reduce({}, :merge).with_indifferent_access
 
-        @api      = attributes[:recaptcha_api_url] || GOOGLE_API_URL
-        @secret   = attributes[:recaptcha_secret]
-        @ip       = request.ip
+        @api       = attributes[:recaptcha_api_url] || GOOGLE_API_URL
+        @secret    = attributes[:recaptcha_secret]
+        @ip        = request.ip
+        @min_score = attributes[:recaptcha_min_score] || MIN_SCORE
       end
 
       def verify(response_code)
@@ -25,6 +27,8 @@ module Locomotive
           response: response_code,
           remoteip: @ip
         }})
+
+        return false if _response.parsed_response['score'] < MIN_SCORE
 
         _response.parsed_response['success']
       end


### PR DESCRIPTION
The recaptcha score is a value between 0 and 1.

Google [recommends](https://developers.google.com/recaptcha/docs/v3#site_verify_response) to analyze traffic and configure the acceptable score.

On a particular site in production, we notice a lot of spam with a score of 0.1 whereas legit submissions have a score of 0.9.

So I select a default value of 0.2, but I'm happy to set anything else that you'd feel more sensible.
