### PR TITLE
Adding meta robots input texts for pages and content entries pages

### DIFF
--- a/lib/locomotive/steam/adapters/filesystem/sanitizers/page.rb
+++ b/lib/locomotive/steam/adapters/filesystem/sanitizers/page.rb
@@ -97,7 +97,7 @@ module Locomotive::Steam
               %i(
                 title slug fullpath template_path redirect_url
                 sections_content sections_dropzone_content
-                seo_title meta_description meta_keywords
+                seo_title meta_description meta_keywords meta_robots
               ).each do |name|
                 page[name][locale] ||= page[name][default_locale]
               end

--- a/lib/locomotive/steam/adapters/filesystem/yaml_loaders/page.rb
+++ b/lib/locomotive/steam/adapters/filesystem/yaml_loaders/page.rb
@@ -88,7 +88,7 @@ module Locomotive
 
               # set the attributes
               %i(
-                title slug redirect_url seo_title meta_description meta_keywords
+                title slug redirect_url seo_title meta_description meta_keywords meta_robots
                 listed published position
                 sections_content sections_dropzone_content editable_elements raw_template
               ).each do |name|
@@ -118,7 +118,7 @@ module Locomotive
               }
 
               %i(
-                redirect_url seo_title meta_description meta_keywords
+                redirect_url seo_title meta_description meta_keywords meta_robots
                 sections_content sections_dropzone_content
               ).each do |name|
                 _attributes[name] = { locale => attributes.delete(name) }
@@ -138,7 +138,7 @@ module Locomotive
               update_editable_elements(leaf, attributes.delete(:editable_elements), locale)
 
               %i(
-                redirect_url seo_title meta_description meta_keywords
+                redirect_url seo_title meta_description meta_keywords meta_robots
                 sections_content sections_dropzone_content
               ).each do |name|
                 leaf[name][locale] ||= attributes.delete(name)

--- a/lib/locomotive/steam/liquid/drops/content_entry.rb
+++ b/lib/locomotive/steam/liquid/drops/content_entry.rb
@@ -4,7 +4,7 @@ module Locomotive
       module Drops
         class ContentEntry < I18nBase
 
-          delegate :_slug, :_translated, :seo_title, :meta_keywords, :meta_description, :created_at, :updated_at, to: :@_source
+          delegate :_slug, :_translated, :seo_title, :meta_keywords, :meta_description, :meta_robots, :created_at, :updated_at, to: :@_source
 
           alias :_permalink :_slug
 

--- a/lib/locomotive/steam/liquid/drops/page.rb
+++ b/lib/locomotive/steam/liquid/drops/page.rb
@@ -5,7 +5,7 @@ module Locomotive
         class Page < I18nBase
 
           delegate :position, :fullpath, :depth, :redirect_url, :handle, to: :@_source
-          delegate :seo_title, :meta_keywords, :meta_description, to: :@_source
+          delegate :seo_title, :meta_keywords, :meta_description, :meta_robots, to: :@_source
           delegate :listed?, :published?, :redirect?, :index?, :is_layout?, :templatized?, to: :@_source
           delegate :sections_content, :sections_dropzone_content, to: :@_source
 

--- a/lib/locomotive/steam/liquid/tags/seo.rb
+++ b/lib/locomotive/steam/liquid/tags/seo.rb
@@ -26,6 +26,7 @@ module Locomotive
               %{
                 <meta name="description" content="#{self.value_for(:meta_description, context)}">
                 <meta name="keywords" content="#{self.value_for(:meta_keywords, context)}">
+                <meta name="robots" content="#{self.value_for(:meta_robots, context)}">
               }
             end
 

--- a/lib/locomotive/steam/middlewares/templatized_page.rb
+++ b/lib/locomotive/steam/middlewares/templatized_page.rb
@@ -28,8 +28,9 @@ module Locomotive::Steam
           # log it
           debug_log "Found content entry: #{entry._label}"
         else
+          log "C"*25
           url = services.url_builder.url_for(page_not_found, locale)
-          redirect_to url, 302
+          redirect_to url, 404
         end
       end
 

--- a/lib/locomotive/steam/repositories/content_entry_repository.rb
+++ b/lib/locomotive/steam/repositories/content_entry_repository.rb
@@ -17,7 +17,7 @@ module Locomotive
 
       # Entity mapping
       mapping :content_entries, entity: ContentEntry do
-        localized_attributes :_slug, :seo_title, :meta_description, :meta_keywords
+        localized_attributes :_slug, :seo_title, :meta_description, :meta_keywords, :meta_robots
 
         default_attribute :content_type, -> (repository) { repository.content_type }
       end

--- a/lib/locomotive/steam/repositories/page_repository.rb
+++ b/lib/locomotive/steam/repositories/page_repository.rb
@@ -10,7 +10,7 @@ module Locomotive
         localized_attributes :title, :slug, :permalink,
           :source, :raw_template, :template_path, :data_path, :redirect_url, :fullpath,
           :sections_content, :sections_dropzone_content,
-          :seo_title, :meta_description, :meta_keywords
+          :seo_title, :meta_description, :meta_keywords, :meta_robots
 
         embedded_association :editable_elements, EditableElementRepository
       end

--- a/spec/fixtures/default/app/views/pages/index.liquid.haml
+++ b/spec/fixtures/default/app/views/pages/index.liquid.haml
@@ -11,6 +11,7 @@ title: Home page
 
     %meta{ content: "{{ site.meta_description }}", name: "description" }
     %meta{ content: "{{ site.meta_keywords }}", name: "keywords" }
+    %meta{ content: "{{ site.meta_robots }}", name: "robots" }
 
     {{ '/foo/bar' | auto_discovery_link_tag: 'rel:alternate', 'type:application/atom+xml', 'title:A title' }}
 

--- a/spec/unit/liquid/drops/content_entry_spec.rb
+++ b/spec/unit/liquid/drops/content_entry_spec.rb
@@ -4,7 +4,7 @@ describe Locomotive::Steam::Liquid::Drops::ContentEntry do
 
   let(:site)      { instance_double('Site', default_locale: 'en') }
   let(:type)      { instance_double('Type', fields_by_name: { title: instance_double('Field', type: :string ) }) }
-  let(:entry)     { instance_double('Article', _id: 42, localized_attributes: {}, content_type: type, title: 'Hello world', _label: 'Hello world', _slug: 'hello-world', _translated: false, seo_title: 'seo title', meta_keywords: 'keywords', meta_description: 'description', created_at: 0, updated_at: 1) }
+  let(:entry)     { instance_double('Article', _id: 42, localized_attributes: {}, content_type: type, title: 'Hello world', _label: 'Hello world', _slug: 'hello-world', _translated: false, seo_title: 'seo title', meta_keywords: 'keywords', meta_description: 'description', meta_robots: 'noindex', created_at: 0, updated_at: 1) }
   let(:assigns)   { {} }
   let(:services)  { Locomotive::Steam::Services.build_instance }
   let(:context)   { ::Liquid::Context.new(assigns, {}, { services: services, site: site, locale: 'en' }) }
@@ -20,6 +20,7 @@ describe Locomotive::Steam::Liquid::Drops::ContentEntry do
     expect(subject.seo_title).to eq 'seo title'
     expect(subject.meta_keywords).to eq 'keywords'
     expect(subject.meta_description).to eq 'description'
+    expect(subject.meta_robots).to eq 'noindex'
     expect(subject.created_at).to eq 0
     expect(subject.updated_at).to eq 1
   end
@@ -110,7 +111,7 @@ describe Locomotive::Steam::Liquid::Drops::ContentEntry do
 
     describe 'belong_to content type' do
 
-      let(:entry)       { instance_double('Article', _id: 42, localized_attributes: {}, content_type: type, title: 'Hello world', _label: 'Hello world', _slug: 'hello-world', _translated: false, seo_title: 'seo title', meta_keywords: 'keywords', meta_description: 'description', created_at: 0, updated_at: 1, author: author) }
+      let(:entry)       { instance_double('Article', _id: 42, localized_attributes: {}, content_type: type, title: 'Hello world', _label: 'Hello world', _slug: 'hello-world', _translated: false, seo_title: 'seo title', meta_keywords: 'keywords', meta_description: 'description', meta_robots: 'noindex', created_at: 0, updated_at: 1, author: author) }
       let(:type)        { instance_double('Type', fields_by_name: { title: instance_double('StringField', type: :string ), author: instance_double('Author', type: :belongs_to), picture: instance_double('FileField', type: :file), category: instance_double('SelectField', type: :select) }) }
       let(:author)      { instance_double('Author', _slug: 'john-doe', localized_attributes: {}) }
       let(:picture_field) { Locomotive::Steam::ContentEntry::FileField.new('foo.png', 'http://assets.dev', 0, 42) }
@@ -147,7 +148,7 @@ describe Locomotive::Steam::Liquid::Drops::ContentEntry do
 
   describe '#as_json' do
 
-    let(:entry)       { instance_double('Article', _id: 42, localized_attributes: {}, content_type: type, title: 'Hello world', _label: 'Hello world', _slug: 'hello-world', _translated: false, seo_title: 'seo title', meta_keywords: 'keywords', meta_description: 'description', created_at: 0, updated_at: 1, author: author, authors: authors) }
+    let(:entry)       { instance_double('Article', _id: 42, localized_attributes: {}, content_type: type, title: 'Hello world', _label: 'Hello world', _slug: 'hello-world', _translated: false, seo_title: 'seo title', meta_keywords: 'keywords', meta_description: 'description', meta_robots: 'noindex', created_at: 0, updated_at: 1, author: author, authors: authors) }
     let(:type)        { instance_double('Type', fields_by_name: { title: instance_double('StringField', type: :string ), author: instance_double('Author', type: :belongs_to), authors: instance_double('Author', type: :many_to_many), picture: instance_double('FileField', type: :file), category: instance_double('SelectField', type: :select) }) }
     let(:author)      { instance_double('Author', _slug: 'john-doe', localized_attributes: {}) }
     let(:authors)     { instance_double('Authors', all: [author]) }

--- a/spec/unit/liquid/drops/page_spec.rb
+++ b/spec/unit/liquid/drops/page_spec.rb
@@ -6,7 +6,7 @@ describe Locomotive::Steam::Liquid::Drops::Page do
   let(:services)  { Locomotive::Steam::Services.build_instance }
   let(:site)      { instance_double('Site', default_locale: 'en') }
   let(:context)   { ::Liquid::Context.new(assigns, {}, { locale: 'en', services: services, site: site }) }
-  let(:page)      { instance_double('Page', id: 42, localized_attributes: [], title: 'Index', slug: 'index', fullpath: 'index', content_type: nil, depth: 1, templatized?: false, listed?: true, published?: true, is_layout?: true, redirect?: false, seo_title: 'seo title', redirect_url: '/', handle: 'index', meta_keywords: 'keywords', meta_description: 'description') }
+  let(:page)      { instance_double('Page', id: 42, localized_attributes: [], title: 'Index', slug: 'index', fullpath: 'index', content_type: nil, depth: 1, templatized?: false, listed?: true, published?: true, is_layout?: true, redirect?: false, seo_title: 'seo title', redirect_url: '/', handle: 'index', meta_keywords: 'keywords', meta_description: 'description', meta_robots: 'noindex') }
   let(:drop)      { described_class.new(page).tap { |d| d.context = context } }
 
   subject { drop }
@@ -25,6 +25,7 @@ describe Locomotive::Steam::Liquid::Drops::Page do
     expect(subject.seo_title).to eq 'seo title'
     expect(subject.meta_keywords).to eq 'keywords'
     expect(subject.meta_description).to eq 'description'
+    expect(subject.meta_robots).to eq 'robots'
     expect(subject.listed?).to eq true
     expect(subject.redirect?).to eq false
     expect(subject.is_layout?).to eq true

--- a/spec/unit/liquid/tags/seo_spec.rb
+++ b/spec/unit/liquid/tags/seo_spec.rb
@@ -5,7 +5,7 @@ describe Locomotive::Steam::Liquid::Tags::SEO do
   let(:page)          { nil }
   let(:content_entry) { nil }
 
-  let(:site)      { liquid_instance_double('Site', name: 'Acme', seo_title: 'Acme (SEO)', meta_description: 'A short site description', meta_keywords: 'test only cat dog') }
+  let(:site)      { liquid_instance_double('Site', name: 'Acme', seo_title: 'Acme (SEO)', meta_description: 'A short site description', meta_keywords: 'test only cat dog', meta_robots: 'noindex,nofollow') }
   let(:assigns)   { { 'site' => site, 'page' => page, 'content_entry' => content_entry } }
   let(:context)   { ::Liquid::Context.new(assigns, {}, {}) }
 
@@ -30,7 +30,7 @@ describe Locomotive::Steam::Liquid::Tags::SEO do
 
       describe 'no seo_title site property' do
 
-        let(:site) { liquid_instance_double('Site', name: 'Acme', seo_title: nil, meta_description: 'A short site description', meta_keywords: 'test only cat dog') }
+        let(:site) { liquid_instance_double('Site', name: 'Acme', seo_title: nil, meta_description: 'A short site description', meta_keywords: 'test only cat dog', meta_robots: 'noindex,nofollow') }
         it { is_expected.to eq '<title>Acme</title>' }
 
       end
@@ -66,7 +66,7 @@ describe Locomotive::Steam::Liquid::Tags::SEO do
 
     describe 'with a page' do
 
-      let(:page) { liquid_instance_double('Page', meta_description: "It's snowing", meta_keywords: 'snow') }
+      let(:page) { liquid_instance_double('Page', meta_description: "It's snowing", meta_keywords: 'snow', meta_robots: 'nofollow') }
       it { is_expected.to include %Q[<meta name="description" content="It's snowing">] }
       it { is_expected.to include %Q[<meta name="keywords" content="snow">] }
 
@@ -74,7 +74,7 @@ describe Locomotive::Steam::Liquid::Tags::SEO do
 
     describe 'with a content entry' do
 
-      let(:content_entry) { liquid_instance_double('Entry', meta_description: "It's snowing", meta_keywords: 'snow') }
+      let(:content_entry) { liquid_instance_double('Entry', meta_description: "It's snowing", meta_keywords: 'snow', meta_robots: 'nofollow') }
       it { is_expected.to include %Q[<meta name="description" content="It's snowing">] }
       it { is_expected.to include %Q[<meta name="keywords" content="snow">] }
 


### PR DESCRIPTION
I think it is good to be able to modify the meta robots tag for each page and content entry (similar feature than meta keywords & meta description edition). This PR should be released with the related PR (it will be created in few moments) in the engine project https://github.com/locomotivecms/engine.