### PR TITLE
[FIX] locale detection by filepath when deploying using compound locale (i.e. pt-BR)

### DIFF
--- a/lib/locomotive/steam/adapters/filesystem/yaml_loaders/page.rb
+++ b/lib/locomotive/steam/adapters/filesystem/yaml_loaders/page.rb
@@ -60,7 +60,7 @@ module Locomotive
 
             def load_data
               Dir.glob(File.join(data_path, '**', '*.json')).each do |filepath|
-                filepath  =~ /#{data_path}\/([a-z]+)\//
+                filepath  =~ /#{data_path}\/([\w]{2})-*([\w]{2})*\//
                 data      = safe_json_file_load(filepath)
                 locale    = $1.to_sym
 


### PR DESCRIPTION
When deploying a site using a compound locale (e.g. pt-BR) was getting 

"undefined method `to_sym` for nil:NilClass"

This PRs allowed to deploy using compound locales.