### PR TITLE
Ruby 3.2 deprecation crashes wagon/steam

### DIFF
--- a/lib/locomotive/steam/adapters/filesystem/yaml_loader.rb
+++ b/lib/locomotive/steam/adapters/filesystem/yaml_loader.rb
@@ -19,7 +19,7 @@ module Locomotive::Steam
         end
 
         def _load(path, frontmatter = false, strict = false, &block)
-          if File.exists?(path)
+          if File.exist?(path)
             yaml      = File.open(path).read.force_encoding('utf-8')
             template  = nil
 
@@ -72,7 +72,7 @@ module Locomotive::Steam
         end
 
         def safe_json_file_load(path)
-          return {} unless File.exists?(path)
+          return {} unless File.exist?(path)
 
           json = File.read(path)
 

--- a/lib/locomotive/steam/adapters/filesystem/yaml_loaders/content_entry.rb
+++ b/lib/locomotive/steam/adapters/filesystem/yaml_loaders/content_entry.rb
@@ -70,7 +70,7 @@ module Locomotive
 
               _path = File.join(site_path, 'public', path)
 
-              File.exists?(_path) ? File.size(_path) : nil
+              File.exist?(_path) ? File.size(_path) : nil
             end
 
             def modify_for_associations(attributes)
@@ -114,7 +114,7 @@ module Locomotive
 
               path = File.join(site_path, 'data', env.to_s, 'content_entries')
 
-              @path = File.exists?(path) ? path : File.join(site_path, 'data') # allow the legacy folder
+              @path = File.exist?(path) ? path : File.join(site_path, 'data') # allow the legacy folder
             end
 
             def content_type

--- a/lib/locomotive/steam/initializers/dragonfly.rb
+++ b/lib/locomotive/steam/initializers/dragonfly.rb
@@ -33,7 +33,7 @@ module Locomotive
           convert   = ENV['IMAGE_MAGICK_CONVERT'] || `which convert`.strip.presence || '/usr/local/bin/convert'
           identify  = ENV['IMAGE_MAGICK_IDENTIFY'] || `which identify`.strip.presence || '/usr/local/bin/identify'
 
-          if File.exists?(convert)
+          if File.exist?(convert)
             { convert_command: convert, identify_command: identify }
           else
             missing_image_magick


### PR DESCRIPTION
"File.exists?" as been deprecated in ruby 3.2 and was replaced with "File.exist?"