### PR TITLE
Updated gems deemed unsecure by CVE or GHSA violations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,10 +11,10 @@ group :development do
 
   gem 'rake'
 
-  gem 'puma',               '~> 6.4.0'
+  gem 'puma',               '~> 6.4.3'
   gem 'haml',               '~> 6.2.3'
 
-  gem 'rack', '~> 3.0'
+  gem 'rack', '~> 3.1.11'
   gem 'rack-mini-profiler', '~> 0.10.1'
   gem 'flamegraph'
   gem 'stackprof' # ruby 2.1+ only

--- a/locomotivecms_steam.gemspec
+++ b/locomotivecms_steam.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'mongo',      '~> 2.18.2'
   spec.add_development_dependency 'origin',     '~> 2.3.1'
 
-  spec.add_dependency 'nokogiri',               '~> 1.16.7'
-  spec.add_dependency 'sanitize',               '~> 6.0.1'
+  spec.add_dependency 'nokogiri',               '~> 1.18.4'
+  spec.add_dependency 'sanitize',               '~> 6.1.3'
   spec.add_dependency 'morphine',               '~> 0.1.1'
   spec.add_dependency 'httparty',               '~> 0.22.0'
   spec.add_dependency 'chronic',                '~> 0.10.2'
@@ -28,15 +28,15 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'liquid',                 '~> 4.0.4'
 
   spec.add_dependency 'rack-rewrite',           '~> 1.5.1'
-  spec.add_dependency 'rack-cache',             '>= 1.7', '< 2'
-  spec.add_dependency 'rack-session',           '~> 2.0.0'
-  spec.add_dependency 'rack_csrf',              '~> 2.6.0'
-  spec.add_dependency 'dragonfly',              '~> 1.4.0'
+  spec.add_dependency 'rack-cache',             '>= 1.13', '< 2'
+  spec.add_dependency 'rack-session',           '~> 2.1.0'
+  spec.add_dependency 'rack_csrf',              '~> 2.7.0'
+  spec.add_dependency 'dragonfly',              '~> 1.4.1'
   spec.add_dependency 'moneta',                 '~> 1.6.0'
 
   spec.add_dependency 'execjs',                 '~> 2.9.1'
 
-  spec.add_dependency 'kramdown',               '~> 2.3.0'
+  spec.add_dependency 'kramdown',               '~> 2.5.0'
   spec.add_dependency 'RedCloth',               '~> 4.3.2'
   spec.add_dependency 'mimetype-fu',            '~> 0.1.2'
   spec.add_dependency 'mime-types',             '~> 3.5.0'


### PR DESCRIPTION
Name: net-imap
Version: 0.4.16
CVE: CVE-2025-25186
GHSA: GHSA-7fc5-f82f-cx69
Criticality: Medium
URL: https://github.com/ruby/net-imap/security/advisories/GHSA-7fc5-f82f-cx69
Title: Possible DoS by memory exhaustion in net-imap
Solution: update to '~> 0.3.8', '~> 0.4.19', '>= 0.5.6'

Name: nokogiri
Version: 1.16.7
GHSA: GHSA-mrxw-mxhj-p664
Criticality: High
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-mrxw-mxhj-p664
Title: Nokogiri updates packaged libxslt to v1.1.43 to resolve multiple CVEs
Solution: update to '>= 1.18.4'

Name: nokogiri
Version: 1.16.7
GHSA: GHSA-vvfq-8hwr-qm4m
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-vvfq-8hwr-qm4m
Title: Nokogiri updates packaged libxml2 to 2.13.6 to resolve CVE-2025-24928 and CVE-2024-56171
Solution: update to '>= 1.18.3'

Name: nokogiri
Version: 1.16.7
GHSA: GHSA-mrxw-mxhj-p664
Criticality: High
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-mrxw-mxhj-p664
Title: Nokogiri updates packaged libxslt to v1.1.43 to resolve multiple CVEs
Solution: update to '>= 1.18.4'

Name: nokogiri
Version: 1.16.7
GHSA: GHSA-vvfq-8hwr-qm4m
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-vvfq-8hwr-qm4m
Title: Nokogiri updates packaged libxml2 to 2.13.6 to resolve CVE-2025-24928 and CVE-2024-56171
Solution: update to '>= 1.18.3'

Name: rack
Version: 3.1.7
CVE: CVE-2025-25184
GHSA: GHSA-7g2v-jj9q-g3rg
Criticality: Unknown
URL: https://github.com/rack/rack/security/advisories/GHSA-7g2v-jj9q-g3rg
Title: Possible Log Injection in Rack::CommonLogger
Solution: update to '~> 2.2.11', '~> 3.0.12', '>= 3.1.10'

Name: rack
Version: 3.1.7
CVE: CVE-2025-27111
GHSA: GHSA-8cgq-6mh2-7j6v
Criticality: Unknown
URL: https://github.com/rack/rack/security/advisories/GHSA-8cgq-6mh2-7j6v
Title: Escape Sequence Injection vulnerability in Rack lead to Possible Log Injection
Solution: update to '~> 2.2.12', '~> 3.0.13', '>= 3.1.11'

Name: rack
Version: 3.1.7
CVE: CVE-2025-27610
GHSA: GHSA-7wqh-767x-r66v
Criticality: High
URL: https://github.com/rack/rack/security/advisories/GHSA-7wqh-767x-r66v
Title: Local File Inclusion in Rack::Static
Solution: update to '~> 2.2.13', '~> 3.0.14', '>= 3.1.12'

Name: rexml
Version: 3.3.8
CVE: CVE-2024-49761
GHSA: GHSA-2rxp-v6pw-ch6m
Criticality: High
URL: https://github.com/ruby/rexml/security/advisories/GHSA-2rxp-v6pw-ch6m
Title: REXML ReDoS vulnerability
Solution: update to '>= 3.3.9'