### PR TITLE
Update section.rb to fix boolean defaults

### DIFF
--- a/lib/locomotive/steam/adapters/filesystem/sanitizers/section.rb
+++ b/lib/locomotive/steam/adapters/filesystem/sanitizers/section.rb
@@ -60,7 +60,7 @@ module Locomotive::Steam
             settings = content['settings'] ||= {}
 
             definition['settings'].each do |setting|
-              settings[setting['id']] ||= setting['default']
+              settings[setting['id']] = setting['default'] if settings[setting['id']].nil?
             end
 
             # no definition of blocks, no need to continue


### PR DESCRIPTION
The use of `||=` drops defaults when they're explicitly false. As a result, boolean defaults assigned to `false` are never set in the final settings hash. That omission means `section.settings.setting_enabled` returns `nil` instead of `false`.